### PR TITLE
feat(builtins): remove builtins dir from configs

### DIFF
--- a/crates/created-swarm/src/swarm.rs
+++ b/crates/created-swarm/src/swarm.rs
@@ -316,7 +316,6 @@ pub fn create_swarm_with_runtime<RT: AquaRuntime>(
         UnresolvedConfig::deserialize(node_config).expect("created_swarm: deserialize config");
 
     let mut resolved = node_config.resolve().expect("failed to resolve config");
-    create_dir(&resolved.dir_config.builtins_base_dir).expect("create builtins dir");
 
     resolved.node_config.transport_config.transport = Transport::Memory;
     resolved.node_config.transport_config.socket_timeout = TRANSPORT_TIMEOUT;

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -83,10 +83,6 @@ pub fn services_base_dir(base_dir: &Path) -> PathBuf {
     base_dir.join("services")
 }
 
-pub fn builtins_base_dir(base_dir: &Path) -> PathBuf {
-    base_dir.join("builtins")
-}
-
 pub fn avm_base_dir(base_dir: &Path) -> PathBuf {
     base_dir.join("stepper")
 }

--- a/crates/server-config/src/dir_config.rs
+++ b/crates/server-config/src/dir_config.rs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::defaults::{avm_base_dir, builtins_base_dir, default_base_dir, services_base_dir};
+use crate::defaults::{avm_base_dir, default_base_dir, services_base_dir};
 
 use air_interpreter_fs::air_interpreter_path;
 use fs_utils::{canonicalize, create_dirs, to_abs_path};
@@ -30,9 +30,6 @@ pub struct UnresolvedDirConfig {
 
     /// Base directory for resources needed by application services
     pub services_base_dir: Option<PathBuf>,
-
-    /// Base directory for builtin services
-    pub builtins_base_dir: Option<PathBuf>,
 
     /// Base directory for resources needed by application services
     pub avm_base_dir: Option<PathBuf>,
@@ -51,7 +48,6 @@ impl UnresolvedDirConfig {
         let base = to_abs_path(self.base_dir);
 
         let services_base_dir = self.services_base_dir.unwrap_or(services_base_dir(&base));
-        let builtins_base_dir = self.builtins_base_dir.unwrap_or(builtins_base_dir(&base));
         let avm_base_dir = self.avm_base_dir.unwrap_or(avm_base_dir(&base));
         let air_interpreter_path = self
             .air_interpreter_path
@@ -63,7 +59,6 @@ impl UnresolvedDirConfig {
             &base,
             &services_base_dir,
             &avm_base_dir,
-            &builtins_base_dir,
             &spell_base_dir,
             &keypairs_base_dir,
         ])
@@ -71,7 +66,6 @@ impl UnresolvedDirConfig {
 
         let base = canonicalize(base)?;
         let services_base_dir = canonicalize(services_base_dir)?;
-        let builtins_base_dir = canonicalize(builtins_base_dir)?;
         let avm_base_dir = canonicalize(avm_base_dir)?;
         let spell_base_dir = canonicalize(spell_base_dir)?;
         let keypairs_base_dir = canonicalize(keypairs_base_dir)?;
@@ -79,7 +73,6 @@ impl UnresolvedDirConfig {
         Ok(ResolvedDirConfig {
             base_dir: base,
             services_base_dir,
-            builtins_base_dir,
             avm_base_dir,
             air_interpreter_path,
             spell_base_dir,
@@ -92,8 +85,6 @@ impl UnresolvedDirConfig {
 pub struct ResolvedDirConfig {
     pub base_dir: PathBuf,
     pub services_base_dir: PathBuf,
-    /// Directory where configs for autodeployed builtins are stored
-    pub builtins_base_dir: PathBuf,
     /// Directory where particle's prev_data is stored
     pub avm_base_dir: PathBuf,
     /// Directory where interpreter's WASM module is stored

--- a/crates/server-config/src/lib.rs
+++ b/crates/server-config/src/lib.rs
@@ -40,7 +40,7 @@ mod resolved_config;
 mod services_config;
 pub mod system_services_config;
 
-pub use defaults::{builtins_base_dir, *};
+pub use defaults::*;
 pub use resolved_config::load_config;
 pub use resolved_config::load_config_with_args;
 pub use resolved_config::ConfigData;

--- a/nox/src/node.rs
+++ b/nox/src/node.rs
@@ -546,7 +546,7 @@ mod tests {
     use config_utils::to_peer_id;
     use connected_client::ConnectedClient;
     use fs_utils::to_abs_path;
-    use server_config::{builtins_base_dir, default_base_dir, load_config_with_args};
+    use server_config::{default_base_dir, load_config_with_args};
 
     use crate::Node;
 
@@ -554,7 +554,6 @@ mod tests {
     async fn run_node() {
         let base_dir = default_base_dir();
         fs_utils::create_dir(&base_dir).unwrap();
-        fs_utils::create_dir(builtins_base_dir(&base_dir)).unwrap();
         write_default_air_interpreter(&air_interpreter_path(&base_dir)).unwrap();
 
         let mut config = load_config_with_args(vec![], None)


### PR DESCRIPTION
## Description
Builtins dir is unused, but is created on the Nox start.

## Motivation
It causes build to fail in nox-distro if `/builtins` is not chowned.

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [x] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [x] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

