### PR TITLE
feat(http): Added http healthcheck endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "fluence-libp2p",
  "fs-utils",
  "futures",
+ "health",
  "humantime 2.1.0",
  "key-manager",
  "libp2p",
@@ -2140,6 +2141,13 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "health"
+version = "0.1.0"
+dependencies = [
+ "eyre",
 ]
 
 [[package]]
@@ -4061,6 +4069,7 @@ dependencies = [
  "fs-utils",
  "fstrings",
  "futures",
+ "health",
  "humantime-serde",
  "hyper",
  "itertools 0.11.0",
@@ -4369,6 +4378,7 @@ dependencies = [
  "fluence-app-service",
  "fluence-keypair",
  "futures",
+ "health",
  "humantime-serde",
  "itertools 0.11.0",
  "ivalue-utils",
@@ -4481,6 +4491,7 @@ dependencies = [
  "fluence-app-service",
  "fluence-libp2p",
  "fs-utils",
+ "health",
  "humantime-serde",
  "json-utils",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/peer-metrics",
     "crates/spell-event-bus",
     "crates/key-manager",
+    "crates/health",
     "sorcerer",
     "crates/nox-tests",
     "nox",
@@ -86,6 +87,7 @@ script-storage = { path = "script-storage" }
 spell-storage = { path = "spell-storage" }
 particle-execution = { path = "particle-execution" }
 system-services = { path = "crates/system-services" }
+health = { path = "crates/health" }
 
 # spell
 fluence-spell-dtos = "=0.5.17"

--- a/aquamarine/Cargo.toml
+++ b/aquamarine/Cargo.toml
@@ -39,3 +39,4 @@ anyhow = "1.0.72"
 eyre = { workspace = true }
 bytesize = "1.2.0"
 async-trait = "0.1.71"
+health = { workspace = true }

--- a/aquamarine/src/aquamarine.rs
+++ b/aquamarine/src/aquamarine.rs
@@ -23,6 +23,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use fluence_libp2p::PeerId;
+use health::HealthCheckRegistry;
 use key_manager::KeyManager;
 use particle_execution::{ParticleFunctionStatic, ServiceFunction};
 use particle_protocol::Particle;
@@ -53,12 +54,18 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> AquamarineBackend<RT, F> {
         out: EffectsChannel,
         plumber_metrics: Option<ParticleExecutorMetrics>,
         vm_pool_metrics: Option<VmPoolMetrics>,
+        health_registry: Option<&mut HealthCheckRegistry>,
         key_manager: KeyManager,
     ) -> (Self, AquamarineApi) {
         // TODO: make `100` configurable
         let (outlet, inlet) = mpsc::channel(100);
         let sender = AquamarineApi::new(outlet, config.execution_timeout);
-        let vm_pool = VmPool::new(config.pool_size, runtime_config, vm_pool_metrics);
+        let vm_pool = VmPool::new(
+            config.pool_size,
+            runtime_config,
+            vm_pool_metrics,
+            health_registry,
+        );
         let host_peer_id = key_manager.get_host_peer_id();
         let plumber = Plumber::new(vm_pool, builtins, plumber_metrics, key_manager);
         let this = Self {

--- a/aquamarine/src/aquamarine.rs
+++ b/aquamarine/src/aquamarine.rs
@@ -47,6 +47,7 @@ pub struct AquamarineBackend<RT: AquaRuntime, F> {
 }
 
 impl<RT: AquaRuntime, F: ParticleFunctionStatic> AquamarineBackend<RT, F> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: VmPoolConfig,
         runtime_config: RT::Config,

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -23,7 +23,7 @@ impl VMPoolHealth {
 }
 
 impl HealthCheck for VMPoolHealth {
-    fn check(&self) -> eyre::Result<()> {
+    fn status(&self) -> eyre::Result<()> {
         let guard = self.current_count.lock();
         let current = *guard;
         if self.expected_count != current {

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -1,0 +1,39 @@
+use health::HealthCheck;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct VMPoolHealCheck {
+    expected_count: usize,
+    current_count: Arc<Mutex<usize>>,
+}
+
+impl VMPoolHealCheck {
+    pub fn new(expected_count: usize) -> Self {
+        Self {
+            expected_count,
+            current_count: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub fn increment_count(&self) {
+        let mut guard = self.current_count.lock();
+        *guard += 1;
+    }
+}
+
+impl HealthCheck for VMPoolHealCheck {
+    fn check(&self) -> eyre::Result<()> {
+        let guard = self.current_count.lock();
+        let current = *guard;
+        if self.expected_count != current {
+            return Err(eyre::eyre!(
+                "VM pool isn't full. Current: {}, Expected: {}",
+                current,
+                self.expected_count
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -3,12 +3,12 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct VMPoolHealCheck {
+pub struct VMPoolHealth {
     expected_count: usize,
     current_count: Arc<Mutex<usize>>,
 }
 
-impl VMPoolHealCheck {
+impl VMPoolHealth {
     pub fn new(expected_count: usize) -> Self {
         Self {
             expected_count,
@@ -22,7 +22,7 @@ impl VMPoolHealCheck {
     }
 }
 
-impl HealthCheck for VMPoolHealCheck {
+impl HealthCheck for VMPoolHealth {
     fn check(&self) -> eyre::Result<()> {
         let guard = self.current_count.lock();
         let current = *guard;

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -1,30 +1,30 @@
 use health::HealthCheck;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct VMPoolHealth {
     expected_count: usize,
-    current_count: Arc<Mutex<usize>>,
+    current_count: Arc<RwLock<usize>>,
 }
 
 impl VMPoolHealth {
     pub fn new(expected_count: usize) -> Self {
         Self {
             expected_count,
-            current_count: Arc::new(Mutex::new(0)),
+            current_count: Arc::new(RwLock::new(0)),
         }
     }
 
     pub fn increment_count(&self) {
-        let mut guard = self.current_count.lock();
+        let mut guard = self.current_count.write();
         *guard += 1;
     }
 }
 
 impl HealthCheck for VMPoolHealth {
     fn status(&self) -> eyre::Result<()> {
-        let guard = self.current_count.lock();
+        let guard = self.current_count.read();
         let current = *guard;
         if self.expected_count != current {
             return Err(eyre::eyre!(

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -35,3 +35,63 @@ impl HealthCheck for VMPoolHealth {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_vm_pool_health_empty() {
+        let pool_health = VMPoolHealth::new(0);
+        let status = pool_health.status();
+        assert!(status.is_ok());
+    }
+
+    #[test]
+    fn test_vm_pool_health_partial() {
+        let pool_health = VMPoolHealth::new(5);
+        pool_health.increment_count();
+        pool_health.increment_count();
+        pool_health.increment_count();
+
+        let status = pool_health.status();
+        assert!(status.is_err());
+    }
+
+    #[test]
+    fn test_vm_pool_health_full() {
+        let pool_health = VMPoolHealth::new(3);
+        pool_health.increment_count();
+        pool_health.increment_count();
+        pool_health.increment_count();
+
+        let status = pool_health.status();
+        assert!(status.is_ok());
+    }
+
+    #[test]
+    fn test_vm_pool_health_concurrent_access() {
+        let pool_health = VMPoolHealth::new(100);
+        let mut handles = vec![];
+
+        // Simulate concurrent access by spawning multiple threads.
+        for _ in 0..50 {
+            let pool_health_clone = pool_health.clone();
+            let handle = thread::spawn(move || {
+                for _ in 0..2 {
+                    pool_health_clone.increment_count();
+                }
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads to finish.
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let status = pool_health.status();
+        assert!(status.is_ok());
+    }
+}

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -1,31 +1,29 @@
 use health::HealthCheck;
-use parking_lot::RwLock;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Clone)]
 pub struct VMPoolHealth {
     expected_count: usize,
-    current_count: Arc<RwLock<usize>>,
+    current_count: Arc<AtomicUsize>,
 }
 
 impl VMPoolHealth {
     pub fn new(expected_count: usize) -> Self {
         Self {
             expected_count,
-            current_count: Arc::new(RwLock::new(0)),
+            current_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     pub fn increment_count(&self) {
-        let mut guard = self.current_count.write();
-        *guard += 1;
+        self.current_count.fetch_add(1, Ordering::Release);
     }
 }
 
 impl HealthCheck for VMPoolHealth {
     fn status(&self) -> eyre::Result<()> {
-        let guard = self.current_count.read();
-        let current = *guard;
+        let current = self.current_count.load(Ordering::Acquire);
         if self.expected_count != current {
             return Err(eyre::eyre!(
                 "VM pool isn't full. Current: {}, Expected: {}",

--- a/aquamarine/src/health.rs
+++ b/aquamarine/src/health.rs
@@ -1,6 +1,6 @@
 use health::HealthCheck;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct VMPoolHealth {

--- a/aquamarine/src/lib.rs
+++ b/aquamarine/src/lib.rs
@@ -47,6 +47,7 @@ mod command;
 mod config;
 mod deadline;
 mod error;
+mod health;
 mod invoke;
 mod log;
 mod particle_data_store;

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -424,7 +424,7 @@ mod tests {
 
     fn plumber() -> Plumber<VMMock, Arc<MockF>> {
         // Pool is of size 1 so it's easier to control tests
-        let vm_pool = VmPool::new(1, (), None);
+        let vm_pool = VmPool::new(1, (), None, None);
         let builtin_mock = Arc::new(MockF);
         let key_manager = KeyManager::new(
             "keypair".into(),

--- a/aquamarine/src/vm_pool.rs
+++ b/aquamarine/src/vm_pool.rs
@@ -174,7 +174,9 @@ impl<RT: AquaRuntime> VmPool<RT> {
                 match vm {
                     Ok(vm) => {
                         vms[id] = Some(vm);
-                        self.health.as_ref().map(|h| h.increment_count());
+                        if let Some(h) = self.health.as_ref() {
+                            h.increment_count()
+                        }
                     }
                     Err(err) => log::error!("Failed to create vm: {:?}", err), // TODO: don't panic
                 }

--- a/aquamarine/src/vm_pool.rs
+++ b/aquamarine/src/vm_pool.rs
@@ -22,7 +22,7 @@ use health::HealthCheckRegistry;
 use peer_metrics::VmPoolMetrics;
 
 use crate::aqua_runtime::AquaRuntime;
-use crate::health::VMPoolHealCheck;
+use crate::health::VMPoolHealth;
 
 type RuntimeF<RT> = BoxFuture<'static, Result<RT, <RT as AquaRuntime>::Error>>;
 
@@ -41,7 +41,7 @@ pub struct VmPool<RT: AquaRuntime> {
     runtime_config: RT::Config,
     pool_size: usize,
     metrics: Option<VmPoolMetrics>,
-    health: Option<VMPoolHealCheck>,
+    health: Option<VMPoolHealth>,
 }
 
 impl<RT: AquaRuntime> VmPool<RT> {
@@ -53,7 +53,7 @@ impl<RT: AquaRuntime> VmPool<RT> {
         health_registry: Option<&mut HealthCheckRegistry>,
     ) -> Self {
         let health = health_registry.map(|registry| {
-            let health = VMPoolHealCheck::new(pool_size);
+            let health = VMPoolHealth::new(pool_size);
             registry.register("vm_pool", health.clone());
             health
         });

--- a/aquamarine/src/vm_pool.rs
+++ b/aquamarine/src/vm_pool.rs
@@ -53,9 +53,9 @@ impl<RT: AquaRuntime> VmPool<RT> {
         health_registry: Option<&mut HealthCheckRegistry>,
     ) -> Self {
         let health = health_registry.map(|registry| {
-            let vm_pool = VMPoolHealCheck::new(pool_size);
-            registry.register("vm_pool", vm_pool.clone());
-            vm_pool
+            let health = VMPoolHealCheck::new(pool_size);
+            registry.register("vm_pool", health.clone());
+            health
         });
 
         let mut this = Self {

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "health"
+version = "0.1.0"
+authors = ["Fluence Labs"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eyre = { workspace = true }

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -26,7 +26,7 @@ impl HealthCheckRegistry {
         let mut oks = Vec::new();
 
         for (name, check) in &self.checks {
-            match check.check() {
+            match check.status() {
                 Ok(_) => oks.push(name.clone()),
                 Err(_) => {
                     fails.push(name.clone());

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -7,7 +7,7 @@ pub trait HealthCheck: Send + Sync + 'static {
 }
 
 pub struct HealthCheckRegistry {
-    checks: Vec<(String, Box<dyn HealthCheck>)>,
+    checks: Vec<(&'static str, Box<dyn HealthCheck>)>,
 }
 
 ///  The result of the health check, which can be one of the following:
@@ -15,9 +15,9 @@ pub struct HealthCheckRegistry {
 /// HealthCheckResult::Fail(fails): If all health checks fail. fails is a vector containing the names of the failed health checks.
 /// HealthCheckResult::Warning(oks, fails): If some health checks pass while others fail. oks is a vector containing the names of the passed health checks, and fails is a vector containing the names of the failed health checks.
 pub enum HealthStatus {
-    Ok(Vec<String>),
-    Warning(Vec<String>, Vec<String>),
-    Fail(Vec<String>),
+    Ok(Vec<&'static str>),
+    Warning(Vec<&'static str>, Vec<&'static str>),
+    Fail(Vec<&'static str>),
 }
 /// A HealthCheckRegistry is a collection of health checks that can be registered and executed.
 /// Each health check is associated with a name and is expected to implement the HealthCheck trait.
@@ -26,8 +26,8 @@ impl HealthCheckRegistry {
         HealthCheckRegistry { checks: Vec::new() }
     }
 
-    pub fn register(&mut self, name: &str, check: impl HealthCheck) {
-        self.checks.push((name.to_string(), Box::new(check)));
+    pub fn register(&mut self, name: &'static str, check: impl HealthCheck) {
+        self.checks.push((name, Box::new(check)));
     }
 
     pub fn status(&self) -> HealthStatus {
@@ -36,9 +36,9 @@ impl HealthCheckRegistry {
 
         for (name, check) in &self.checks {
             match check.status() {
-                Ok(_) => oks.push(name.clone()),
+                Ok(_) => oks.push(*name),
                 Err(_) => {
-                    fails.push(name.clone());
+                    fails.push(*name);
                 }
             }
         }

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -21,7 +21,7 @@ impl HealthCheckRegistry {
         self.checks.push((name.to_string(), Box::new(check)));
     }
 
-    pub fn check(&self) -> HealthCheckResult {
+    pub fn status(&self) -> HealthStatus {
         let mut fails = Vec::new();
         let mut oks = Vec::new();
 

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -1,0 +1,51 @@
+pub trait HealthCheck: Send + Sync + 'static {
+    fn check(&self) -> eyre::Result<()>;
+}
+
+pub struct HealthCheckRegistry {
+    checks: Vec<(String, Box<dyn HealthCheck>)>,
+}
+
+pub enum HealthCheckResult {
+    Ok(Vec<String>),
+    Warning(Vec<String>, Vec<String>),
+    Fail(Vec<String>),
+}
+
+impl HealthCheckRegistry {
+    pub fn new() -> Self {
+        HealthCheckRegistry { checks: Vec::new() }
+    }
+
+    pub fn register(&mut self, name: &str, check: impl HealthCheck) {
+        self.checks.push((name.to_string(), Box::new(check)));
+    }
+
+    pub fn check(&self) -> HealthCheckResult {
+        let mut fails = Vec::new();
+        let mut oks = Vec::new();
+
+        for (name, check) in &self.checks {
+            match check.check() {
+                Ok(_) => oks.push(name.clone()),
+                Err(_) => {
+                    fails.push(name.clone());
+                }
+            }
+        }
+
+        if fails.is_empty() {
+            HealthCheckResult::Ok(oks)
+        } else if fails.len() == self.checks.len() {
+            HealthCheckResult::Fail(fails)
+        } else {
+            HealthCheckResult::Warning(oks, fails)
+        }
+    }
+}
+
+impl Default for HealthCheckRegistry {
+    fn default() -> Self {
+        HealthCheckRegistry::new()
+    }
+}

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -36,7 +36,7 @@ impl HealthCheckRegistry {
 
         if fails.is_empty() {
             HealthCheckResult::Ok(oks)
-        } else if fails.len() == self.checks.len() {
+        } else if oks.is_empty() {
             HealthCheckResult::Fail(fails)
         } else {
             HealthCheckResult::Warning(oks, fails)

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! See [`HealthCheckRegistry`] for details.
 
-
 pub trait HealthCheck: Send + Sync + 'static {
     fn status(&self) -> eyre::Result<()>;
 }

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -4,7 +4,7 @@
 
 
 pub trait HealthCheck: Send + Sync + 'static {
-    fn check(&self) -> eyre::Result<()>;
+    fn status(&self) -> eyre::Result<()>;
 }
 
 pub struct HealthCheckRegistry {
@@ -15,7 +15,7 @@ pub struct HealthCheckRegistry {
 /// HealthCheckResult::Ok(oks): If all health checks pass successfully. oks is a vector containing the names of the passed health checks.
 /// HealthCheckResult::Fail(fails): If all health checks fail. fails is a vector containing the names of the failed health checks.
 /// HealthCheckResult::Warning(oks, fails): If some health checks pass while others fail. oks is a vector containing the names of the passed health checks, and fails is a vector containing the names of the failed health checks.
-pub enum HealthCheckResult {
+pub enum HealthStatus {
     Ok(Vec<String>),
     Warning(Vec<String>, Vec<String>),
     Fail(Vec<String>),
@@ -45,11 +45,11 @@ impl HealthCheckRegistry {
         }
 
         if fails.is_empty() {
-            HealthCheckResult::Ok(oks)
+            HealthStatus::Ok(oks)
         } else if oks.is_empty() {
-            HealthCheckResult::Fail(fails)
+            HealthStatus::Fail(fails)
         } else {
-            HealthCheckResult::Warning(oks, fails)
+            HealthStatus::Warning(oks, fails)
         }
     }
 }

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -1,3 +1,8 @@
+//! Health check registry implementation.
+//!
+//! See [`HealthCheckRegistry`] for details.
+
+
 pub trait HealthCheck: Send + Sync + 'static {
     fn check(&self) -> eyre::Result<()>;
 }
@@ -6,12 +11,17 @@ pub struct HealthCheckRegistry {
     checks: Vec<(String, Box<dyn HealthCheck>)>,
 }
 
+///  The result of the health check, which can be one of the following:
+/// HealthCheckResult::Ok(oks): If all health checks pass successfully. oks is a vector containing the names of the passed health checks.
+/// HealthCheckResult::Fail(fails): If all health checks fail. fails is a vector containing the names of the failed health checks.
+/// HealthCheckResult::Warning(oks, fails): If some health checks pass while others fail. oks is a vector containing the names of the passed health checks, and fails is a vector containing the names of the failed health checks.
 pub enum HealthCheckResult {
     Ok(Vec<String>),
     Warning(Vec<String>, Vec<String>),
     Fail(Vec<String>),
 }
-
+/// A HealthCheckRegistry is a collection of health checks that can be registered and executed.
+/// Each health check is associated with a name and is expected to implement the HealthCheck trait.
 impl HealthCheckRegistry {
     pub fn new() -> Self {
         HealthCheckRegistry { checks: Vec::new() }

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -71,6 +71,10 @@ pub fn default_metrics_enabled() -> bool {
     true
 }
 
+pub fn default_health_check_enabled() -> bool {
+    true
+}
+
 pub fn default_services_metrics_timer_resolution() -> Duration {
     Duration::from_secs(60)
 }

--- a/crates/server-config/src/network_config.rs
+++ b/crates/server-config/src/network_config.rs
@@ -38,7 +38,6 @@ pub struct NetworkConfig {
     pub bootstrap_frequency: usize,
     pub connectivity_metrics: Option<ConnectivityMetrics>,
     pub connection_pool_metrics: Option<ConnectionPoolMetrics>,
-    #[allow(deprecated)]
     pub connection_limits: ConnectionLimits,
 }
 

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -72,6 +72,9 @@ pub struct UnresolvedNodeConfig {
     pub metrics_config: MetricsConfig,
 
     #[serde(flatten)]
+    pub health_config: HealthConfig,
+
+    #[serde(flatten)]
     pub http_config: Option<HttpConfig>,
 
     #[serde(default)]
@@ -178,6 +181,7 @@ impl UnresolvedNodeConfig {
             external_address: self.external_address,
             external_multiaddresses: self.external_multiaddresses,
             metrics_config: self.metrics_config,
+            health_config: self.health_config,
             bootstrap_config: self.bootstrap_config,
             root_weights: self.root_weights,
             services_envs: self.services_envs,
@@ -304,6 +308,8 @@ pub struct NodeConfig {
 
     pub metrics_config: MetricsConfig,
 
+    pub health_config: HealthConfig,
+
     pub bootstrap_config: BootstrapConfig,
 
     pub root_weights: HashMap<PeerIdSerializable, u32>,
@@ -397,6 +403,13 @@ pub struct MetricsConfig {
 
     #[serde(default = "default_max_builtin_metrics_storage_size")]
     pub max_builtin_metrics_storage_size: usize,
+}
+
+#[derive(Clone, Deserialize, Serialize, Derivative)]
+#[derivative(Debug)]
+pub struct HealthConfig {
+    #[serde(default = "default_health_check_enabled")]
+    pub health_check_enabled: bool,
 }
 
 #[derive(Clone, Deserialize, Serialize, Derivative)]

--- a/nox/Cargo.toml
+++ b/nox/Cargo.toml
@@ -16,6 +16,7 @@ connection-pool = { workspace = true }
 script-storage = { workspace = true }
 aquamarine = { workspace = true }
 sorcerer = { workspace = true }
+health = { workspace = true }
 dhat = { version = "0.3.2", optional = true }
 
 serde_json = { workspace = true }

--- a/nox/src/behaviour/network.rs
+++ b/nox/src/behaviour/network.rs
@@ -28,7 +28,8 @@ use kademlia::{Kademlia, KademliaConfig};
 use particle_protocol::{Particle, PROTOCOL_NAME};
 use server_config::NetworkConfig;
 
-use crate::connectivity::{BootstrapNodesHealthCheck, Connectivity, ConnectivityHealthChecks};
+use crate::connectivity::Connectivity;
+use crate::health::{BootstrapNodesHealthCheck, ConnectivityHealthChecks};
 
 /// Coordinates protocols, so they can cooperate
 #[derive(NetworkBehaviour)]

--- a/nox/src/behaviour/network.rs
+++ b/nox/src/behaviour/network.rs
@@ -23,11 +23,12 @@ use libp2p::{
 use tokio::sync::mpsc;
 
 use connection_pool::ConnectionPoolBehaviour;
+use health::HealthCheckRegistry;
 use kademlia::{Kademlia, KademliaConfig};
 use particle_protocol::{Particle, PROTOCOL_NAME};
 use server_config::NetworkConfig;
 
-use crate::connectivity::Connectivity;
+use crate::connectivity::{BootstrapNodesHealthCheck, Connectivity, ConnectivityHealthChecks};
 
 /// Coordinates protocols, so they can cooperate
 #[derive(NetworkBehaviour)]
@@ -40,7 +41,10 @@ pub struct FluenceNetworkBehaviour {
 }
 
 impl FluenceNetworkBehaviour {
-    pub fn new(cfg: NetworkConfig) -> (Self, Connectivity, mpsc::Receiver<Particle>) {
+    pub fn new(
+        cfg: NetworkConfig,
+        health_registry: Option<&mut HealthCheckRegistry>,
+    ) -> (Self, Connectivity, mpsc::Receiver<Particle>) {
         let local_public_key = cfg.key_pair.public();
         let identify = Identify::new(
             IdentifyConfig::new(PROTOCOL_NAME.into(), local_public_key)
@@ -71,6 +75,15 @@ impl FluenceNetworkBehaviour {
             ping,
         };
 
+        let bootstrap_nodes = cfg.bootstrap_nodes.clone();
+
+        let health = health_registry.map(|registry| {
+            let bootstrap_nodes = BootstrapNodesHealthCheck::new(bootstrap_nodes);
+            registry.register("bootstrap_nodes", bootstrap_nodes.clone());
+
+            ConnectivityHealthChecks { bootstrap_nodes }
+        });
+
         let connectivity = Connectivity {
             peer_id: cfg.local_peer_id,
             kademlia: kademlia_api,
@@ -78,6 +91,7 @@ impl FluenceNetworkBehaviour {
             bootstrap_nodes: cfg.bootstrap_nodes.into_iter().collect(),
             bootstrap_frequency: cfg.bootstrap_frequency,
             metrics: cfg.connectivity_metrics,
+            health,
         };
 
         (this, connectivity, particle_stream)

--- a/nox/src/behaviour/network.rs
+++ b/nox/src/behaviour/network.rs
@@ -29,7 +29,7 @@ use particle_protocol::{Particle, PROTOCOL_NAME};
 use server_config::NetworkConfig;
 
 use crate::connectivity::Connectivity;
-use crate::health::{BootstrapNodesHealthCheck, ConnectivityHealthChecks};
+use crate::health::{BootstrapNodesHealth, ConnectivityHealth};
 
 /// Coordinates protocols, so they can cooperate
 #[derive(NetworkBehaviour)]
@@ -79,10 +79,10 @@ impl FluenceNetworkBehaviour {
         let bootstrap_nodes = cfg.bootstrap_nodes.clone();
 
         let health = health_registry.map(|registry| {
-            let bootstrap_nodes = BootstrapNodesHealthCheck::new(bootstrap_nodes);
+            let bootstrap_nodes = BootstrapNodesHealth::new(bootstrap_nodes);
             registry.register("bootstrap_nodes", bootstrap_nodes.clone());
 
-            ConnectivityHealthChecks { bootstrap_nodes }
+            ConnectivityHealth { bootstrap_nodes }
         });
 
         let connectivity = Connectivity {

--- a/nox/src/connectivity.rs
+++ b/nox/src/connectivity.rs
@@ -15,18 +15,16 @@
  */
 
 use std::cmp::min;
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::collections::HashSet;
 use std::time::Duration;
 
+use crate::health::ConnectivityHealthChecks;
 use connection_pool::{ConnectionPoolApi, ConnectionPoolT, LifecycleEvent};
 use fluence_libp2p::PeerId;
 use futures::{stream::iter, StreamExt};
-use health::HealthCheck;
 use humantime_serde::re::humantime::format_duration as pretty;
 use kademlia::{KademliaApi, KademliaApiT, KademliaError};
 use libp2p::Multiaddr;
-use parking_lot::Mutex;
 use particle_protocol::{Contact, Particle, SendStatus};
 use peer_metrics::{ConnectivityMetrics, Resolution};
 use tokio::time::sleep;
@@ -277,51 +275,5 @@ impl AsRef<KademliaApi> for Connectivity {
 impl AsRef<ConnectionPoolApi> for Connectivity {
     fn as_ref(&self) -> &ConnectionPoolApi {
         &self.connection_pool
-    }
-}
-
-#[derive(Clone)]
-pub struct ConnectivityHealthChecks {
-    pub bootstrap_nodes: BootstrapNodesHealthCheck,
-}
-
-#[derive(Clone)]
-pub struct BootstrapNodesHealthCheck {
-    bootstrap_nodes_statuses: Arc<Mutex<HashMap<Multiaddr, bool>>>,
-}
-
-impl BootstrapNodesHealthCheck {
-    pub fn new(bootstrap_nodes: Vec<Multiaddr>) -> Self {
-        let bootstrap_nodes_statuses = bootstrap_nodes
-            .into_iter()
-            .map(|addr| (addr, false))
-            .collect::<HashMap<_, _>>();
-        Self {
-            bootstrap_nodes_statuses: Arc::new(Mutex::new(bootstrap_nodes_statuses)),
-        }
-    }
-
-    fn on_bootstrap_disconnected(&self, addresses: Vec<Multiaddr>) {
-        let mut guard = self.bootstrap_nodes_statuses.lock();
-        for addr in addresses {
-            guard.insert(addr, false);
-        }
-    }
-
-    fn on_bootstrap_connected(&self, addr: Multiaddr) {
-        let mut guard = self.bootstrap_nodes_statuses.lock();
-        guard.insert(addr, true);
-    }
-}
-
-impl HealthCheck for BootstrapNodesHealthCheck {
-    fn check(&self) -> eyre::Result<()> {
-        let guard = self.bootstrap_nodes_statuses.lock();
-        for (addr, connected) in guard.iter() {
-            if !connected {
-                return Err(eyre::eyre!("Bootstrap {} is not connected", addr));
-            }
-        }
-        Ok(())
     }
 }

--- a/nox/src/connectivity.rs
+++ b/nox/src/connectivity.rs
@@ -15,19 +15,21 @@
  */
 
 use std::cmp::min;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
-
-use futures::{stream::iter, StreamExt};
-use humantime_serde::re::humantime::format_duration as pretty;
-use libp2p::Multiaddr;
-use tokio::time::sleep;
 
 use connection_pool::{ConnectionPoolApi, ConnectionPoolT, LifecycleEvent};
 use fluence_libp2p::PeerId;
+use futures::{stream::iter, StreamExt};
+use health::HealthCheck;
+use humantime_serde::re::humantime::format_duration as pretty;
 use kademlia::{KademliaApi, KademliaApiT, KademliaError};
+use libp2p::Multiaddr;
+use parking_lot::Mutex;
 use particle_protocol::{Contact, Particle, SendStatus};
 use peer_metrics::{ConnectivityMetrics, Resolution};
+use tokio::time::sleep;
 
 use crate::tasks::Tasks;
 
@@ -44,6 +46,7 @@ pub struct Connectivity {
     /// This setting specify that N.
     pub bootstrap_frequency: usize,
     pub metrics: Option<ConnectivityMetrics>,
+    pub health: Option<ConnectivityHealthChecks>,
 }
 
 impl Connectivity {
@@ -207,6 +210,7 @@ impl Connectivity {
         let kademlia = self.kademlia;
         let bootstrap_nodes = self.bootstrap_nodes;
         let metrics = self.metrics.as_ref();
+        let health = self.health.as_ref();
 
         let disconnections = {
             use tokio_stream::StreamExt as stream;
@@ -215,11 +219,17 @@ impl Connectivity {
             let events = pool.lifecycle_events();
             stream::filter_map(events, move |e| {
                 if let LifecycleEvent::Disconnected(Contact { addresses, .. }) = e {
-                    metrics.map(|m| m.bootstrap_disconnected.inc());
                     let addresses = addresses.into_iter();
                     let addresses = addresses.filter(|addr| bootstrap_nodes.contains(addr));
-                    let addresses = iter(addresses.collect::<Vec<_>>());
-                    return Some(addresses);
+                    let addresses = addresses.collect::<Vec<_>>();
+                    if !addresses.is_empty() {
+                        metrics.map(|m| m.bootstrap_disconnected.inc());
+                        health.map(|h| {
+                            h.bootstrap_nodes
+                                .on_bootstrap_disconnected(addresses.clone())
+                        });
+                    };
+                    return Some(iter(addresses));
                 }
                 None
             })
@@ -240,6 +250,7 @@ impl Connectivity {
                     let ok = kademlia.add_contact(contact);
                     debug_assert!(ok, "kademlia.add_contact");
                     metrics.map(|m| m.bootstrap_connected.inc());
+                    health.map(|h| h.bootstrap_nodes.on_bootstrap_connected(addr));
                     break;
                 }
 
@@ -266,5 +277,51 @@ impl AsRef<KademliaApi> for Connectivity {
 impl AsRef<ConnectionPoolApi> for Connectivity {
     fn as_ref(&self) -> &ConnectionPoolApi {
         &self.connection_pool
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectivityHealthChecks {
+    pub bootstrap_nodes: BootstrapNodesHealthCheck,
+}
+
+#[derive(Clone)]
+pub struct BootstrapNodesHealthCheck {
+    bootstrap_nodes_statuses: Arc<Mutex<HashMap<Multiaddr, bool>>>,
+}
+
+impl BootstrapNodesHealthCheck {
+    pub fn new(bootstrap_nodes: Vec<Multiaddr>) -> Self {
+        let bootstrap_nodes_statuses = bootstrap_nodes
+            .into_iter()
+            .map(|addr| (addr, false))
+            .collect::<HashMap<_, _>>();
+        Self {
+            bootstrap_nodes_statuses: Arc::new(Mutex::new(bootstrap_nodes_statuses)),
+        }
+    }
+
+    fn on_bootstrap_disconnected(&self, addresses: Vec<Multiaddr>) {
+        let mut guard = self.bootstrap_nodes_statuses.lock();
+        for addr in addresses {
+            guard.insert(addr, false);
+        }
+    }
+
+    fn on_bootstrap_connected(&self, addr: Multiaddr) {
+        let mut guard = self.bootstrap_nodes_statuses.lock();
+        guard.insert(addr, true);
+    }
+}
+
+impl HealthCheck for BootstrapNodesHealthCheck {
+    fn check(&self) -> eyre::Result<()> {
+        let guard = self.bootstrap_nodes_statuses.lock();
+        for (addr, connected) in guard.iter() {
+            if !connected {
+                return Err(eyre::eyre!("Bootstrap {} is not connected", addr));
+            }
+        }
+        Ok(())
     }
 }

--- a/nox/src/connectivity.rs
+++ b/nox/src/connectivity.rs
@@ -222,10 +222,10 @@ impl Connectivity {
                     let addresses = addresses.collect::<Vec<_>>();
                     if !addresses.is_empty() {
                         metrics.map(|m| m.bootstrap_disconnected.inc());
-                        health.map(|h| {
+                        if let Some(h) = health {
                             h.bootstrap_nodes
                                 .on_bootstrap_disconnected(addresses.clone())
-                        });
+                        }
                     };
                     return Some(iter(addresses));
                 }
@@ -248,7 +248,9 @@ impl Connectivity {
                     let ok = kademlia.add_contact(contact);
                     debug_assert!(ok, "kademlia.add_contact");
                     metrics.map(|m| m.bootstrap_connected.inc());
-                    health.map(|h| h.bootstrap_nodes.on_bootstrap_connected(addr));
+                    if let Some(h) = health {
+                        h.bootstrap_nodes.on_bootstrap_connected(addr)
+                    }
                     break;
                 }
 

--- a/nox/src/connectivity.rs
+++ b/nox/src/connectivity.rs
@@ -18,7 +18,7 @@ use std::cmp::min;
 use std::collections::HashSet;
 use std::time::Duration;
 
-use crate::health::ConnectivityHealthChecks;
+use crate::health::ConnectivityHealth;
 use connection_pool::{ConnectionPoolApi, ConnectionPoolT, LifecycleEvent};
 use fluence_libp2p::PeerId;
 use futures::{stream::iter, StreamExt};
@@ -44,7 +44,7 @@ pub struct Connectivity {
     /// This setting specify that N.
     pub bootstrap_frequency: usize,
     pub metrics: Option<ConnectivityMetrics>,
-    pub health: Option<ConnectivityHealthChecks>,
+    pub health: Option<ConnectivityHealth>,
 }
 
 impl Connectivity {

--- a/nox/src/health.rs
+++ b/nox/src/health.rs
@@ -49,3 +49,67 @@ impl HealthCheck for BootstrapNodesHealth {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_bootstrap_nodes_health_all_connected() {
+        let bootstrap_nodes = vec![
+            "/ip4/127.0.0.1/tcp/5000".parse().unwrap(),
+            "/ip4/127.0.0.1/tcp/5001".parse().unwrap(),
+        ];
+        let bootstrap_health = BootstrapNodesHealth::new(bootstrap_nodes.clone());
+
+        // Simulate connections to the bootstrap nodes
+        bootstrap_health.on_bootstrap_connected(bootstrap_nodes[0].clone());
+        bootstrap_health.on_bootstrap_connected(bootstrap_nodes[1].clone());
+
+        let status = bootstrap_health.status();
+        assert!(status.is_ok());
+    }
+
+    #[test]
+    fn test_bootstrap_nodes_health_partial_connected() {
+        let bootstrap_nodes = vec![
+            "/ip4/127.0.0.1/tcp/5000".parse().unwrap(),
+            "/ip4/127.0.0.1/tcp/5001".parse().unwrap(),
+        ];
+        let bootstrap_health = BootstrapNodesHealth::new(bootstrap_nodes.clone());
+
+        // Simulate connections to only one of the bootstrap nodes
+        bootstrap_health.on_bootstrap_connected(bootstrap_nodes[0].clone());
+
+        let status = bootstrap_health.status();
+        assert!(status.is_err());
+    }
+
+    #[test]
+    fn test_bootstrap_nodes_health_concurrent_access() {
+        let bootstrap_nodes = vec![
+            "/ip4/127.0.0.1/tcp/5000".parse().unwrap(),
+            "/ip4/127.0.0.1/tcp/5001".parse().unwrap(),
+        ];
+        let bootstrap_health = Arc::new(BootstrapNodesHealth::new(bootstrap_nodes.clone()));
+        let health_clone = bootstrap_health.clone();
+
+        let bootstrap_node = bootstrap_nodes[0].clone();
+        // Simulate concurrent access by spawning multiple threads.
+        let thread_handle = thread::spawn(move || {
+            let health = health_clone;
+            // Simulate connections to the bootstrap nodes in separate threads.
+            health.on_bootstrap_connected(bootstrap_node);
+        });
+
+        // Simulate connections to the bootstrap nodes in the main thread.
+        bootstrap_health.on_bootstrap_connected(bootstrap_nodes[1].clone());
+
+        // Wait for the spawned thread to finish.
+        thread_handle.join().unwrap();
+
+        let status = bootstrap_health.status();
+        assert!(status.is_ok());
+    }
+}

--- a/nox/src/health.rs
+++ b/nox/src/health.rs
@@ -1,0 +1,51 @@
+use health::HealthCheck;
+use libp2p::Multiaddr;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct ConnectivityHealthChecks {
+    pub bootstrap_nodes: BootstrapNodesHealthCheck,
+}
+
+#[derive(Clone)]
+pub struct BootstrapNodesHealthCheck {
+    bootstrap_nodes_statuses: Arc<Mutex<HashMap<Multiaddr, bool>>>,
+}
+
+impl BootstrapNodesHealthCheck {
+    pub fn new(bootstrap_nodes: Vec<Multiaddr>) -> Self {
+        let bootstrap_nodes_statuses = bootstrap_nodes
+            .into_iter()
+            .map(|addr| (addr, false))
+            .collect::<HashMap<_, _>>();
+        Self {
+            bootstrap_nodes_statuses: Arc::new(Mutex::new(bootstrap_nodes_statuses)),
+        }
+    }
+
+    pub fn on_bootstrap_disconnected(&self, addresses: Vec<Multiaddr>) {
+        let mut guard = self.bootstrap_nodes_statuses.lock();
+        for addr in addresses {
+            guard.insert(addr, false);
+        }
+    }
+
+    pub fn on_bootstrap_connected(&self, addr: Multiaddr) {
+        let mut guard = self.bootstrap_nodes_statuses.lock();
+        guard.insert(addr, true);
+    }
+}
+
+impl HealthCheck for BootstrapNodesHealthCheck {
+    fn check(&self) -> eyre::Result<()> {
+        let guard = self.bootstrap_nodes_statuses.lock();
+        for (addr, connected) in guard.iter() {
+            if !connected {
+                return Err(eyre::eyre!("Bootstrap {} is not connected", addr));
+            }
+        }
+        Ok(())
+    }
+}

--- a/nox/src/health.rs
+++ b/nox/src/health.rs
@@ -5,16 +5,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
-pub struct ConnectivityHealthChecks {
-    pub bootstrap_nodes: BootstrapNodesHealthCheck,
+pub struct ConnectivityHealth {
+    pub bootstrap_nodes: BootstrapNodesHealth,
 }
 
 #[derive(Clone)]
-pub struct BootstrapNodesHealthCheck {
+pub struct BootstrapNodesHealth {
     bootstrap_nodes_statuses: Arc<Mutex<HashMap<Multiaddr, bool>>>,
 }
 
-impl BootstrapNodesHealthCheck {
+impl BootstrapNodesHealth {
     pub fn new(bootstrap_nodes: Vec<Multiaddr>) -> Self {
         let bootstrap_nodes_statuses = bootstrap_nodes
             .into_iter()
@@ -38,7 +38,7 @@ impl BootstrapNodesHealthCheck {
     }
 }
 
-impl HealthCheck for BootstrapNodesHealthCheck {
+impl HealthCheck for BootstrapNodesHealth {
     fn check(&self) -> eyre::Result<()> {
         let guard = self.bootstrap_nodes_statuses.lock();
         for (addr, connected) in guard.iter() {

--- a/nox/src/health.rs
+++ b/nox/src/health.rs
@@ -1,6 +1,6 @@
 use health::HealthCheck;
 use libp2p::Multiaddr;
-use parking_lot::Mutex;
+use parking_lot::{RwLock};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -11,7 +11,7 @@ pub struct ConnectivityHealth {
 
 #[derive(Clone)]
 pub struct BootstrapNodesHealth {
-    bootstrap_nodes_statuses: Arc<Mutex<HashMap<Multiaddr, bool>>>,
+    bootstrap_nodes_statuses: Arc<RwLock<HashMap<Multiaddr, bool>>>,
 }
 
 impl BootstrapNodesHealth {
@@ -21,26 +21,26 @@ impl BootstrapNodesHealth {
             .map(|addr| (addr, false))
             .collect::<HashMap<_, _>>();
         Self {
-            bootstrap_nodes_statuses: Arc::new(Mutex::new(bootstrap_nodes_statuses)),
+            bootstrap_nodes_statuses: Arc::new(RwLock::new(bootstrap_nodes_statuses)),
         }
     }
 
     pub fn on_bootstrap_disconnected(&self, addresses: Vec<Multiaddr>) {
-        let mut guard = self.bootstrap_nodes_statuses.lock();
+        let mut guard = self.bootstrap_nodes_statuses.write();
         for addr in addresses {
             guard.insert(addr, false);
         }
     }
 
     pub fn on_bootstrap_connected(&self, addr: Multiaddr) {
-        let mut guard = self.bootstrap_nodes_statuses.lock();
+        let mut guard = self.bootstrap_nodes_statuses.write();
         guard.insert(addr, true);
     }
 }
 
 impl HealthCheck for BootstrapNodesHealth {
-    fn check(&self) -> eyre::Result<()> {
-        let guard = self.bootstrap_nodes_statuses.lock();
+    fn status(&self) -> eyre::Result<()> {
+        let guard = self.bootstrap_nodes_statuses.read();
         for (addr, connected) in guard.iter() {
             if !connected {
                 return Err(eyre::eyre!("Bootstrap {} is not connected", addr));

--- a/nox/src/health.rs
+++ b/nox/src/health.rs
@@ -1,6 +1,6 @@
 use health::HealthCheck;
 use libp2p::Multiaddr;
-use parking_lot::{RwLock};
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -80,9 +80,7 @@ async fn handle_health(State(state): State<RouteState>) -> axum::response::Resul
         .as_ref()
         .ok_or((StatusCode::NOT_FOUND, "nothing to see here"))?;
     let result = match registry.status() {
-        HealthStatus::Ok(keys) => {
-            (StatusCode::OK, Json(make_json(keys, "Ok"))).into_response()
-        }
+        HealthStatus::Ok(keys) => (StatusCode::OK, Json(make_json(keys, "Ok"))).into_response(),
         HealthStatus::Warning(ok, fail) => {
             let mut result = make_json(ok, "Ok");
             let mut fail = make_json(fail, "Fail");

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -42,7 +42,7 @@ async fn handle_metrics(State(state): State<RouteState>) -> axum::response::Resu
         )
         .body(body)
         .map_err(|e| {
-            tracing::warn!("Could not create response: {}", e);
+            tracing::warn!("Could not create metric response: {}", e);
             ErrorResponse::from(StatusCode::INTERNAL_SERVER_ERROR)
         })
 }
@@ -70,7 +70,7 @@ async fn handle_versions(State(state): State<RouteState>) -> Response {
 }
 
 async fn handle_health(State(state): State<RouteState>) -> axum::response::Result<Response> {
-    fn make_json(keys: Vec<String>, status: &str) -> Vec<Value> {
+    fn make_json(keys: Vec<&'static str>, status: &str) -> Vec<Value> {
         keys.into_iter().map(|k| json!({k: status})).collect()
     }
 

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -69,6 +69,7 @@ async fn handle_versions(State(state): State<RouteState>) -> Response {
     .into_response()
 }
 
+/// Health check endpoint follows consul contract https://developer.hashicorp.com/consul/docs/services/usage/checks#http-checks
 async fn handle_health(State(state): State<RouteState>) -> axum::response::Result<Response> {
     fn make_json(keys: Vec<&'static str>, status: &str) -> Vec<Value> {
         keys.into_iter().map(|k| json!({k: status})).collect()

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -30,7 +30,7 @@ async fn handle_metrics(State(state): State<RouteState>) -> axum::response::Resu
         .as_ref()
         .ok_or((StatusCode::NOT_FOUND, "nothing to see here"))?;
     encode(&mut buf, registry).map_err(|e| {
-        tracing::warn!("Could not encode metrics: {}", e);
+        tracing::warn!("Metrics encode error: {}", e);
         ErrorResponse::from(StatusCode::INTERNAL_SERVER_ERROR)
     })?;
 

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -276,7 +276,6 @@ mod tests {
             .unwrap();
         let status = response.status();
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-        println!("body: {:?}", String::from_utf8(body.to_vec().clone()));
         assert_eq!(status, StatusCode::OK);
         assert_eq!(&body[..], (r#"[]"#).as_bytes());
     }

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use tokio::sync::Notify;
 
 async fn handler_404() -> impl IntoResponse {
-    (StatusCode::NOT_FOUND, "nothing to see here")
+    (StatusCode::NOT_FOUND, "No such endpoint")
 }
 
 async fn handle_metrics(State(state): State<RouteState>) -> axum::response::Result<Response<Body>> {
@@ -28,7 +28,7 @@ async fn handle_metrics(State(state): State<RouteState>) -> axum::response::Resu
         .0
         .metric_registry
         .as_ref()
-        .ok_or((StatusCode::NOT_FOUND, "nothing to see here"))?;
+        .ok_or((StatusCode::NOT_FOUND, "No such endpoint"))?;
     encode(&mut buf, registry).map_err(|e| {
         tracing::warn!("Metrics encode error: {}", e);
         ErrorResponse::from(StatusCode::INTERNAL_SERVER_ERROR)
@@ -78,7 +78,7 @@ async fn handle_health(State(state): State<RouteState>) -> axum::response::Resul
         .0
         .health_registry
         .as_ref()
-        .ok_or((StatusCode::NOT_FOUND, "nothing to see here"))?;
+        .ok_or((StatusCode::NOT_FOUND, "No such endpoint"))?;
     let result = match registry.status() {
         HealthStatus::Ok(keys) => (StatusCode::OK, Json(make_json(keys, "Ok"))).into_response(),
         HealthStatus::Warning(ok, fail) => {

--- a/nox/src/http.rs
+++ b/nox/src/http.rs
@@ -90,7 +90,7 @@ async fn handle_health(State(state): State<RouteState>) -> axum::response::Resul
             (StatusCode::TOO_MANY_REQUESTS, Json(result)).into_response()
         }
         HealthCheckResult::Fail(keys) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::SERVICE_UNAVAILABLE,
             Json(make_json(keys, "Fail")),
         )
             .into_response(),

--- a/nox/src/lib.rs
+++ b/nox/src/lib.rs
@@ -33,6 +33,7 @@ mod builtins;
 mod connectivity;
 mod dispatcher;
 mod effectors;
+mod health;
 mod http;
 mod layers;
 mod node;

--- a/particle-builtins/Cargo.toml
+++ b/particle-builtins/Cargo.toml
@@ -47,6 +47,7 @@ fluence-app-service = { workspace = true }
 async-trait = { version = "0.1.71" }
 eyre = { workspace = true }
 base64 = { workspace = true }
+health = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -34,6 +34,7 @@ use tokio::sync::RwLock;
 use JValue::Array;
 
 use connection_pool::{ConnectionPoolApi, ConnectionPoolT};
+use health::HealthCheckRegistry;
 use kademlia::{KademliaApi, KademliaApiT};
 use key_manager::KeyManager;
 use now_millis::{now_ms, now_sec};
@@ -107,6 +108,7 @@ where
         config: ServicesConfig,
         services_metrics: ServicesMetrics,
         key_manager: KeyManager,
+        health_registry: Option<&mut HealthCheckRegistry>,
     ) -> Self {
         let modules_dir = &config.modules_dir;
         let blueprint_dir = &config.blueprint_dir;
@@ -123,7 +125,12 @@ where
         let management_peer_id = config.management_peer_id;
         let builtins_management_peer_id = config.builtins_management_peer_id;
         let local_peer_id = config.local_peer_id;
-        let services = ParticleAppServices::new(config, modules.clone(), Some(services_metrics));
+        let services = ParticleAppServices::new(
+            config,
+            modules.clone(),
+            Some(services_metrics),
+            health_registry,
+        );
 
         Self {
             connectivity,

--- a/particle-services/Cargo.toml
+++ b/particle-services/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = { workspace = true }
 derivative = { workspace = true }
 eyre = { workspace = true }
 humantime-serde = { workspace = true }
+health = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -827,7 +827,7 @@ impl ParticleAppServices {
     fn create_persisted_services(&mut self) {
         let services =
             load_persisted_services(&self.config.services_dir, self.config.local_peer_id);
-        let service_count = services.len();
+        let loaded_service_count = services.len();
         if let Some(h) = self.health.as_mut() {
             h.start_creation()
         }
@@ -905,7 +905,7 @@ impl ParticleAppServices {
                 s.aliases
             );
         }
-        if created_service_count == service_count {
+        if created_service_count == loaded_service_count {
             if let Some(h) = self.health.as_mut() {
                 h.finish_creation()
             }

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -43,7 +43,7 @@ use uuid_utils::uuid;
 
 use crate::error::ServiceError;
 use crate::error::ServiceError::{AliasAsServiceId, Forbidden, NoSuchAlias};
-use crate::health::PersistedServiceHealthCheck;
+use crate::health::PersistedServiceHealth;
 use crate::persistence::{
     load_persisted_services, persist_service, remove_persisted_service, PersistedService,
 };
@@ -176,7 +176,7 @@ pub struct ParticleAppServices {
     management_peer_id: PeerId,
     builtins_management_peer_id: PeerId,
     pub metrics: Option<ServicesMetrics>,
-    health: Option<PersistedServiceHealthCheck>,
+    health: Option<PersistedServiceHealth>,
 }
 
 /// firstly, try to find by alias in worker scope, secondly, in root scope
@@ -263,7 +263,7 @@ impl ParticleAppServices {
         let management_peer_id = config.management_peer_id;
         let builtins_management_peer_id = config.builtins_management_peer_id;
         let health = health_registry.map(|registry| {
-            let persisted_services = PersistedServiceHealthCheck::new();
+            let persisted_services = PersistedServiceHealth::new();
             registry.register("persisted_services", persisted_services.clone());
             persisted_services
         });

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -905,7 +905,7 @@ impl ParticleAppServices {
                 s.aliases
             );
         }
-        if created_service_count != service_count {
+        if created_service_count == service_count {
             if let Some(h) = self.health.as_mut() {
                 h.finish_creation()
             }

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -1073,7 +1073,7 @@ mod tests {
             Default::default(),
         );
 
-        ParticleAppServices::new(config, repo, None)
+        ParticleAppServices::new(config, repo, None, None)
     }
 
     fn call_add_alias_raw(

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -841,7 +841,7 @@ impl ParticleAppServices {
             }
         });
 
-        let mut loaded_service_count = 0;
+        let mut created_service_count = 0;
         for s in services {
             let worker_id = s.worker_id.expect("every service must have worker id");
             let start = Instant::now();
@@ -897,7 +897,7 @@ impl ParticleAppServices {
                 replaced.is_none(),
                 "shouldn't replace any existing services"
             );
-            loaded_service_count += 1;
+            created_service_count += 1;
             log::info!(
                 "Persisted service {} created in {}, aliases: {:?}",
                 s.service_id,
@@ -905,7 +905,7 @@ impl ParticleAppServices {
                 s.aliases
             );
         }
-        if loaded_service_count != service_count {
+        if created_service_count != service_count {
             if let Some(h) = self.health.as_mut() {
                 h.finish_creation()
             }

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JValue};
 
 use fluence_libp2p::{peerid_serializer, PeerId};
+use health::{HealthCheck, HealthCheckRegistry};
 use now_millis::now_ms;
 use particle_args::{Args, JError};
 use particle_execution::{FunctionOutcome, ParticleParams, ParticleVault};
@@ -174,6 +175,7 @@ pub struct ParticleAppServices {
     management_peer_id: PeerId,
     builtins_management_peer_id: PeerId,
     pub metrics: Option<ServicesMetrics>,
+    health: Option<PersistedServiceHealthCheck>,
 }
 
 /// firstly, try to find by alias in worker scope, secondly, in root scope
@@ -254,11 +256,17 @@ impl ParticleAppServices {
         config: ServicesConfig,
         modules: ModuleRepository,
         metrics: Option<ServicesMetrics>,
+        health_registry: Option<&mut HealthCheckRegistry>,
     ) -> Self {
         let vault = ParticleVault::new(config.particles_vault_dir.clone());
         let management_peer_id = config.management_peer_id;
         let builtins_management_peer_id = config.builtins_management_peer_id;
-        let this = Self {
+        let health = health_registry.map(|registry| {
+            let persisted_services = PersistedServiceHealthCheck::new();
+            registry.register("persisted_services", persisted_services.clone());
+            persisted_services
+        });
+        let mut this = Self {
             config,
             vault,
             services: <_>::default(),
@@ -267,6 +275,7 @@ impl ParticleAppServices {
             management_peer_id,
             builtins_management_peer_id,
             metrics,
+            health,
         };
 
         this.create_persisted_services();
@@ -814,10 +823,15 @@ impl ParticleAppServices {
         Ok(stats)
     }
 
-    fn create_persisted_services(&self) {
+    fn create_persisted_services(&mut self) {
         let services =
-            load_persisted_services(&self.config.services_dir, self.config.local_peer_id)
-                .into_iter();
+            load_persisted_services(&self.config.services_dir, self.config.local_peer_id);
+        let service_count = services.len();
+        if let Some(h) = self.health.as_mut() {
+            h.start_loading()
+        }
+        let services = services.into_iter();
+
         let services = services.filter_map(|r| match r {
             Ok(service) => service.into(),
             Err(err) => {
@@ -826,6 +840,7 @@ impl ParticleAppServices {
             }
         });
 
+        let mut loaded_service_count = 0;
         for s in services {
             let worker_id = s.worker_id.expect("every service must have worker id");
             let start = Instant::now();
@@ -881,13 +896,18 @@ impl ParticleAppServices {
                 replaced.is_none(),
                 "shouldn't replace any existing services"
             );
-
+            loaded_service_count += 1;
             log::info!(
                 "Persisted service {} created in {}, aliases: {:?}",
                 s.service_id,
                 pretty(start.elapsed()),
                 s.aliases
             );
+        }
+        if loaded_service_count != service_count {
+            if let Some(h) = self.health.as_mut() {
+                h.mark_has_errors()
+            }
         }
     }
 
@@ -1383,4 +1403,47 @@ mod tests {
     //       - get_interface
     //       - list_services
     //       - test on service persisting
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistedServiceHealthCheck {
+    started: Arc<Mutex<bool>>,
+    has_errors: Arc<Mutex<bool>>,
+}
+
+impl PersistedServiceHealthCheck {
+    pub fn new() -> Self {
+        PersistedServiceHealthCheck {
+            started: Arc::new(Mutex::new(false)),
+            has_errors: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    pub fn start_loading(&mut self) {
+        let mut guard = self.started.lock();
+        *guard = true;
+    }
+
+    pub fn mark_has_errors(&mut self) {
+        let mut guard = self.has_errors.lock();
+        *guard = true;
+    }
+}
+
+impl HealthCheck for PersistedServiceHealthCheck {
+    fn check(&self) -> eyre::Result<()> {
+        let started_guard = self.started.lock();
+        let errors_guard = self.has_errors.lock();
+        let started = *started_guard;
+        if started {
+            let has_errors = *errors_guard;
+            if has_errors {
+                Err(eyre::eyre!("Persisted services loading failed"))
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(eyre::eyre!("Not loaded yet"))
+        }
+    }
 }

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -829,7 +829,7 @@ impl ParticleAppServices {
             load_persisted_services(&self.config.services_dir, self.config.local_peer_id);
         let service_count = services.len();
         if let Some(h) = self.health.as_mut() {
-            h.start_loading()
+            h.start_creation()
         }
         let services = services.into_iter();
 
@@ -907,7 +907,7 @@ impl ParticleAppServices {
         }
         if loaded_service_count != service_count {
             if let Some(h) = self.health.as_mut() {
-                h.mark_has_errors()
+                h.finish_creation()
             }
         }
     }

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -12,7 +12,7 @@ impl PersistedServiceHealth {
     pub fn new() -> Self {
         PersistedServiceHealth {
             started: Arc::new(RwLock::new(false)),
-            has_errors: Arc::new(RwLock::new(true)), //this is true by default because we wont to show error while loading in progress
+            has_errors: Arc::new(RwLock::new(true)), // this is true by default because we wont to show error while loading in progress
         }
     }
 

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -40,7 +40,9 @@ impl HealthCheck for PersistedServiceHealth {
                 Ok(())
             }
         } else {
-            Err(eyre::eyre!("Persisted services creation hasn't started yet"))
+            Err(eyre::eyre!(
+                "Persisted services creation hasn't started yet"
+            ))
         }
     }
 }

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -1,6 +1,6 @@
 use health::HealthCheck;
-use std::sync::{Arc};
 use parking_lot::RwLock;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct PersistedServiceHealth {

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -3,14 +3,14 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub struct PersistedServiceHealthCheck {
+pub struct PersistedServiceHealth {
     started: Arc<Mutex<bool>>,
     has_errors: Arc<Mutex<bool>>,
 }
 
-impl PersistedServiceHealthCheck {
+impl PersistedServiceHealth {
     pub fn new() -> Self {
-        PersistedServiceHealthCheck {
+        PersistedServiceHealth {
             started: Arc::new(Mutex::new(false)),
             has_errors: Arc::new(Mutex::new(false)),
         }
@@ -27,7 +27,7 @@ impl PersistedServiceHealthCheck {
     }
 }
 
-impl HealthCheck for PersistedServiceHealthCheck {
+impl HealthCheck for PersistedServiceHealth {
     fn check(&self) -> eyre::Result<()> {
         let started_guard = self.started.lock();
         let errors_guard = self.has_errors.lock();

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -1,36 +1,36 @@
 use health::HealthCheck;
-use parking_lot::Mutex;
-use std::sync::Arc;
+use std::sync::{Arc};
+use parking_lot::RwLock;
 
 #[derive(Debug, Clone)]
 pub struct PersistedServiceHealth {
-    started: Arc<Mutex<bool>>,
-    has_errors: Arc<Mutex<bool>>,
+    started: Arc<RwLock<bool>>,
+    has_errors: Arc<RwLock<bool>>,
 }
 
 impl PersistedServiceHealth {
     pub fn new() -> Self {
         PersistedServiceHealth {
-            started: Arc::new(Mutex::new(false)),
-            has_errors: Arc::new(Mutex::new(false)),
+            started: Arc::new(RwLock::new(false)),
+            has_errors: Arc::new(RwLock::new(false)),
         }
     }
 
-    pub fn start_loading(&mut self) {
-        let mut guard = self.started.lock();
+    pub fn start_creation(&mut self) {
+        let mut guard = self.started.write();
         *guard = true;
     }
 
-    pub fn mark_has_errors(&mut self) {
-        let mut guard = self.has_errors.lock();
+    pub fn finish_creation(&mut self) {
+        let mut guard = self.has_errors.write();
         *guard = true;
     }
 }
 
 impl HealthCheck for PersistedServiceHealth {
-    fn check(&self) -> eyre::Result<()> {
-        let started_guard = self.started.lock();
-        let errors_guard = self.has_errors.lock();
+    fn status(&self) -> eyre::Result<()> {
+        let started_guard = self.started.read();
+        let errors_guard = self.has_errors.read();
         let started = *started_guard;
         if started {
             let has_errors = *errors_guard;

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -40,7 +40,7 @@ impl HealthCheck for PersistedServiceHealth {
                 Ok(())
             }
         } else {
-            Err(eyre::eyre!("Not loaded yet"))
+            Err(eyre::eyre!("Persisted services creation hasn't started yet"))
         }
     }
 }

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -1,0 +1,46 @@
+use health::HealthCheck;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct PersistedServiceHealthCheck {
+    started: Arc<Mutex<bool>>,
+    has_errors: Arc<Mutex<bool>>,
+}
+
+impl PersistedServiceHealthCheck {
+    pub fn new() -> Self {
+        PersistedServiceHealthCheck {
+            started: Arc::new(Mutex::new(false)),
+            has_errors: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    pub fn start_loading(&mut self) {
+        let mut guard = self.started.lock();
+        *guard = true;
+    }
+
+    pub fn mark_has_errors(&mut self) {
+        let mut guard = self.has_errors.lock();
+        *guard = true;
+    }
+}
+
+impl HealthCheck for PersistedServiceHealthCheck {
+    fn check(&self) -> eyre::Result<()> {
+        let started_guard = self.started.lock();
+        let errors_guard = self.has_errors.lock();
+        let started = *started_guard;
+        if started {
+            let has_errors = *errors_guard;
+            if has_errors {
+                Err(eyre::eyre!("Persisted services loading failed"))
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(eyre::eyre!("Not loaded yet"))
+        }
+    }
+}

--- a/particle-services/src/health.rs
+++ b/particle-services/src/health.rs
@@ -12,7 +12,7 @@ impl PersistedServiceHealth {
     pub fn new() -> Self {
         PersistedServiceHealth {
             started: Arc::new(RwLock::new(false)),
-            has_errors: Arc::new(RwLock::new(false)),
+            has_errors: Arc::new(RwLock::new(true)), //this is true by default because we wont to show error while loading in progress
         }
     }
 
@@ -23,7 +23,7 @@ impl PersistedServiceHealth {
 
     pub fn finish_creation(&mut self) {
         let mut guard = self.has_errors.write();
-        *guard = true;
+        *guard = false;
     }
 }
 

--- a/particle-services/src/lib.rs
+++ b/particle-services/src/lib.rs
@@ -36,4 +36,5 @@ pub use crate::error::ServiceError;
 
 mod app_services;
 mod error;
+mod health;
 mod persistence;


### PR DESCRIPTION
## Description
Added health check HTTP endpoint

## Motivation
For now it is not possible to understand the status of node, it can be fully or partially broken. Health check allows to define critical checks to determine a system status.

## Proposed Changes
- Added a health check registry with stores all checkers.
- The HTTP status based on the [consul docs](https://developer.hashicorp.com/consul/docs/services/usage/checks#http-checks).

## Screenshots (if applicable)
![image](https://github.com/fluencelabs/nox/assets/1096153/048d570c-ea2d-4a3f-864d-1ea68973fe70)

## Additional Notes
Also was fixed metric for bootstrap disconnected. it was applied for all disconnected events, not only bootstrap addresses. 

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

