### PR TITLE
feat(builtins): add resolve_alias_opt [NET-528]

### DIFF
--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -215,6 +215,7 @@ where
             ("srv", "create") => wrap(self.create_service(args, particle)),
             ("srv", "get_interface") => wrap(self.get_interface(args, particle)),
             ("srv", "resolve_alias") => wrap(self.resolve_alias(args, particle)),
+            ("srv", "resolve_alias_opt") => wrap(self.resolve_alias_opt(args, particle)),
             ("srv", "add_alias") => wrap_unit(self.add_alias(args, particle)),
             ("srv", "remove") => wrap_unit(self.remove_service(args, particle)),
             ("srv", "info") => wrap(self.get_service_info(args, particle)),
@@ -889,6 +890,18 @@ where
             .resolve_alias(&params.id, params.host_id, alias)?;
 
         Ok(JValue::String(service_id))
+    }
+
+    fn resolve_alias_opt(&self, args: Args, params: ParticleParams) -> Result<JValue, JError> {
+        let mut args = args.function_args.into_iter();
+        let alias: String = Args::next("alias", &mut args)?;
+        let service_id_opt = self
+            .services
+            .resolve_alias(&params.id, params.host_id, alias)
+            .map(|id| vec![JValue::String(id)])
+            .unwrap_or(vec![]);
+
+        Ok(Array(service_id_opt))
     }
 
     fn get_service_info(&self, args: Args, params: ParticleParams) -> Result<JValue, JError> {


### PR DESCRIPTION
## Description
Provide a non-throwing method to resolve alias.

## Motivation
We often call `Srv.resolve_alias` to check whether or not a service exists, but this method throws an error in the absence of this alias, which pollutes nox logs:
```
2023-08-19T00:07:09.186925Z  WARN tokio ThreadId(08) aquamarine::particle_functions: Failed host call "srv" "resolve_alias" "worker-spell" (36us 167ns): "Error: Service with alias 'worker-spell' is not found on worker '12D3KooWMXaLQfKpH6PnfcAjmnPsaz5gLMjZ6knmVN28THaYpd8v'\nNoSuchAlias(\"worker-spell\", PeerId(\"12D3KooWMXaLQfKpH6PnfcAjmnPsaz5gLMjZ6knmVN28THaYpd8v\"))" particle_id="spell_5c84196c-e598-460f-8965-128354d9f140_0"
```
## Proposed Changes
Implement `Srv.resolve_alias_opt`:
```
service Srv:
  resolve_alias_opt(alias: string) -> ?string
```

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

