### PR TITLE
feat(workers): add Worker.get_worker_id [NET-523]

### DIFF
--- a/crates/nox-tests/tests/spells.rs
+++ b/crates/nox-tests/tests/spells.rs
@@ -1936,11 +1936,11 @@ async fn get_worker_peer_id_opt() {
             r#"
             (seq
                 (seq
-                    (call relay ("worker" "get_peer_id_opt") ["deal_id"] worker_peer_id_before)
+                    (call relay ("worker" "get_worker_id") ["deal_id"] worker_peer_id_before)
                     (call relay ("worker" "create") ["deal_id"] worker_peer_id)
                 )
                 (seq
-                    (call relay ("worker" "get_peer_id_opt") ["deal_id"] worker_peer_id_after)
+                    (call relay ("worker" "get_worker_id") ["deal_id"] worker_peer_id_after)
                     (call client ("return" "") [worker_peer_id_before worker_peer_id worker_peer_id_after])
                 )
             )"#,

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -200,11 +200,8 @@ impl Sorcerer {
             CustomService::new(
                 vec![
                     ("create", self.make_worker_create_closure()),
-                    ("get_peer_id", self.make_worker_get_peer_id_closure()),
-                    (
-                        "get_peer_id_opt",
-                        self.make_worker_get_peer_id_opt_closure(),
-                    ),
+                    ("get_peer_id", self.make_worker_get_peer_id_closure()), // TODO: will be DEPRECATED soon
+                    ("get_worker_id", self.make_worker_get_worker_id_closure()),
                     ("remove", self.make_worker_remove_closure()),
                     ("list", self.make_worker_list_closure()),
                 ],
@@ -342,6 +339,7 @@ impl Sorcerer {
         }))
     }
 
+    // TODO: will be DEPRECATED soon
     fn make_worker_get_peer_id_closure(&self) -> ServiceFunction {
         let key_manager = self.key_manager.clone();
         ServiceFunction::Immut(Box::new(move |args, params| {
@@ -350,7 +348,7 @@ impl Sorcerer {
         }))
     }
 
-    fn make_worker_get_peer_id_opt_closure(&self) -> ServiceFunction {
+    fn make_worker_get_worker_id_closure(&self) -> ServiceFunction {
         let key_manager = self.key_manager.clone();
         ServiceFunction::Immut(Box::new(move |args, params| {
             let key_manager = key_manager.clone();

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -201,6 +201,10 @@ impl Sorcerer {
                 vec![
                     ("create", self.make_worker_create_closure()),
                     ("get_peer_id", self.make_worker_get_peer_id_closure()),
+                    (
+                        "get_peer_id_opt",
+                        self.make_worker_get_peer_id_opt_closure(),
+                    ),
                     ("remove", self.make_worker_remove_closure()),
                     ("list", self.make_worker_list_closure()),
                 ],
@@ -343,6 +347,21 @@ impl Sorcerer {
         ServiceFunction::Immut(Box::new(move |args, params| {
             let key_manager = key_manager.clone();
             async move { wrap(get_worker_peer_id(args, params, key_manager)) }.boxed()
+        }))
+    }
+
+    fn make_worker_get_peer_id_opt_closure(&self) -> ServiceFunction {
+        let key_manager = self.key_manager.clone();
+        ServiceFunction::Immut(Box::new(move |args, params| {
+            let key_manager = key_manager.clone();
+            async move {
+                wrap(crate::worker_builins::get_worker_peer_id_opt(
+                    args,
+                    params,
+                    key_manager,
+                ))
+            }
+            .boxed()
         }))
     }
 

--- a/sorcerer/src/worker_builins.rs
+++ b/sorcerer/src/worker_builins.rs
@@ -54,6 +54,22 @@ pub(crate) fn get_worker_peer_id(
     ))
 }
 
+pub(crate) fn get_worker_peer_id_opt(
+    args: Args,
+    params: ParticleParams,
+    key_manager: KeyManager,
+) -> Result<JValue, JError> {
+    let mut args = args.function_args.into_iter();
+    let deal_id: Option<String> = Args::next_opt("deal_id", &mut args)?;
+
+    Ok(JValue::Array(
+        key_manager
+            .get_worker_id(deal_id, params.init_peer_id)
+            .map(|id| vec![JValue::String(id.to_base58())])
+            .unwrap_or_default(),
+    ))
+}
+
 pub(crate) async fn remove_worker(
     args: Args,
     params: ParticleParams,


### PR DESCRIPTION
## Description
Provide a non-throwing method to get worker peer id.

## Motivation
We often call `Worker.get_peer_id` on decider spell to check whether or not a worker exists, but this method throws an error in the absence of a worker, which pollutes nox logs:
```
2023-08-16T17:34:28.579229Z  WARN tokio ThreadId(09) aquamarine::particle_functions: Failed host call "worker" "create" ["0x254fb741db88469b152d30f09396779d02cb7be6"] (146us 875ns): "Error: Worker for 0x254fb741db88469b152d30f09396779d02cb7be6 already exists\nWorkerAlreadyExists { deal_id: \"0x254fb741db88469b152d30f09396779d02cb7be6\" }" particle_id="spell_86b9e58f-0385-4247-a8a1-84e8ae546b58_1"
```
## Proposed Changes
Implement Worker.get_worker_id:
```
service Worker:
  get_worker_id(deal_id: ?string) -> ?PeerId
```

`Worker.get_peer_id` will be deprecated soon.
## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

