### PR TITLE
feat(decider): allow to set ipfs multiaddr from env [fixes NET-544]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "aqua-ipfs-distro"
-version = "0.5.17"
+version = "0.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4babf22570f433b4ccabdfeb57a152712e35b562d36abc096197efc0f1b50d03"
+checksum = "63178298024f3d55029d308292ae71d292b5934f9860431074b84f9eace5fa0c"
 dependencies = [
  "built 0.5.2",
  "maplit",

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -222,100 +222,89 @@ impl UnresolvedNodeConfig {
         if let Ok(aqua_ipfs_external_addr) =
             std::env::var("FLUENCE_ENV_AQUA_IPFS_EXTERNAL_API_MULTIADDR")
         {
-            self.system_services.aqua_ipfs.external_api_multiaddr = aqua_ipfs_external_addr;
             log::warn!(
                 "Override configuration of aqua-ipfs system service (external multiaddr) from ENV"
             );
+            self.system_services.aqua_ipfs.external_api_multiaddr = aqua_ipfs_external_addr;
         }
 
         if let Ok(aqua_ipfs_local_addr) = std::env::var("FLUENCE_ENV_AQUA_IPFS_LOCAL_API_MULTIADDR")
         {
-            self.system_services.aqua_ipfs.local_api_multiaddr = aqua_ipfs_local_addr;
             log::warn!(
                 "Override configuration of aqua-ipfs system service (local multiaddr) from ENV"
             );
+            self.system_services.aqua_ipfs.local_api_multiaddr = aqua_ipfs_local_addr;
         }
 
         if let Ok(enable_decider) = std::env::var("FLUENCE_ENV_CONNECTOR_JOIN_ALL_DEALS") {
             match enable_decider.as_str() {
                 "true" => {
-                    self.system_services.enable.push(ServiceKey::Decider);
                     log::warn!(
                         "Override configuration of system services (enable decider) from ENV"
                     );
+                    self.system_services.enable.push(ServiceKey::Decider);
                 }
                 "false" => {
-                    self.system_services
-                        .enable
-                        .retain(|key| *key != ServiceKey::Decider);
                     log::warn!(
                         "Override configuration of system services (disable decider) from ENV"
                     );
+                    self.system_services
+                        .enable
+                        .retain(|key| *key != ServiceKey::Decider);
                 }
                 _ => {}
             }
         }
         if let Ok(decider_api_endpoint) = std::env::var("FLUENCE_ENV_CONNECTOR_API_ENDPOINT") {
-            self.system_services.decider.network_api_endpoint = decider_api_endpoint;
             log::warn!(
                 "Override configuration of decider system spell (api endpoint) from ENV to {}",
                 decider_api_endpoint
             );
+            self.system_services.decider.network_api_endpoint = decider_api_endpoint;
         }
 
         if let Ok(decider_contract_addr) = std::env::var("FLUENCE_ENV_CONNECTOR_CONTRACT_ADDRESS") {
-            self.system_services.decider.matcher_address = decider_contract_addr;
             log::warn!(
                 "Override configuration of decider system spell (contract address) from ENV to  {}",
                 decider_contract_addr
             );
+            self.system_services.decider.matcher_address = decider_contract_addr;
         }
 
         if let Ok(decider_from_block) = std::env::var("FLUENCE_ENV_CONNECTOR_FROM_BLOCK") {
-            self.system_services.decider.start_block = decider_from_block;
             log::warn!(
                 "Override configuration of decider system spell (from block) from ENV to {}",
                 decider_from_block
             );
+            self.system_services.decider.start_block = decider_from_block;
         }
 
         if let Ok(decider_wallet_key) = std::env::var("FLUENCE_ENV_CONNECTOR_WALLET_KEY") {
+            log::warn!("Override configuration of decider system spell (wallet key) from ENV");
             self.system_services.decider.wallet_key = Some(decider_wallet_key);
-            log::warn!(
-                "Override configuration of decider system spell (wallet key) from ENV to {}",
-                decider_wallet_key
-            );
         }
 
         if let Ok(worker_ipfs_multiaddr) = std::env::var("FLUENCE_ENV_DECIDER_IPFS_MULTIADDR") {
-            self.system_services.decider.worker_ipfs_multiaddr = worker_ipfs_multiaddr;
             log::warn!(
                 "Override configuration of decider system spell (ipfs multiaddr) from ENV to {}",
                 worker_ipfs_multiaddr
             );
+            self.system_services.decider.worker_ipfs_multiaddr = worker_ipfs_multiaddr;
         }
 
         if let Ok(worker_gas) = std::env::var("FLUENCE_ENV_CONNECTOR_WORKER_GAS") {
             match worker_gas.parse() {
                 Ok(worker_gas) => {
-                    self.system_services.decider.worker_gas = worker_gas;
                     log::warn!(
                         "Override configuration of decider system spell (worker gas) from ENV to {}", worker_gas
                     );
+                    self.system_services.decider.worker_gas = worker_gas;
                 }
                 Err(err) => log::warn!(
                     "Unable to override worker gas, value is not a valid u64: {}",
                     err
                 ),
             }
-        }
-
-        if let Ok(decider_wallet_key) = std::env::var("FLUENCE_ENV_CONNECTOR_WALLET_KEY") {
-            self.system_services.decider.wallet_key = Some(decider_wallet_key);
-            log::warn!(
-                "Override configuration of decider system spell (wallet key) from ENV to {}",
-                decider_wallet_key
-            );
         }
     }
 }

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -257,24 +257,42 @@ impl UnresolvedNodeConfig {
         }
         if let Ok(decider_api_endpoint) = std::env::var("FLUENCE_ENV_CONNECTOR_API_ENDPOINT") {
             self.system_services.decider.network_api_endpoint = decider_api_endpoint;
-            log::warn!("Override configuration of decider system spell (api endpoint) from ENV");
+            log::warn!(
+                "Override configuration of decider system spell (api endpoint) from ENV to {}",
+                decider_api_endpoint
+            );
         }
 
         if let Ok(decider_contract_addr) = std::env::var("FLUENCE_ENV_CONNECTOR_CONTRACT_ADDRESS") {
             self.system_services.decider.matcher_address = decider_contract_addr;
             log::warn!(
-                "Override configuration of decider system spell (contract address) from ENV"
+                "Override configuration of decider system spell (contract address) from ENV to  {}",
+                decider_contract_addr
             );
         }
 
         if let Ok(decider_from_block) = std::env::var("FLUENCE_ENV_CONNECTOR_FROM_BLOCK") {
             self.system_services.decider.start_block = decider_from_block;
-            log::warn!("Override configuration of decider system spell (from block) from ENV");
+            log::warn!(
+                "Override configuration of decider system spell (from block) from ENV to {}",
+                decider_from_block
+            );
         }
 
         if let Ok(decider_wallet_key) = std::env::var("FLUENCE_ENV_CONNECTOR_WALLET_KEY") {
             self.system_services.decider.wallet_key = Some(decider_wallet_key);
-            log::warn!("Override configuration of decider system spell (wallet key) from ENV");
+            log::warn!(
+                "Override configuration of decider system spell (wallet key) from ENV to {}",
+                decider_wallet_key
+            );
+        }
+
+        if let Ok(worker_ipfs_multiaddr) = std::env::var("FLUENCE_ENV_DECIDER_IPFS_MULTIADDR") {
+            self.system_services.decider.worker_ipfs_multiaddr = worker_ipfs_multiaddr;
+            log::warn!(
+                "Override configuration of decider system spell (ipfs multiaddr) from ENV to {}",
+                worker_ipfs_multiaddr
+            );
         }
 
         if let Ok(worker_gas) = std::env::var("FLUENCE_ENV_CONNECTOR_WORKER_GAS") {
@@ -282,7 +300,7 @@ impl UnresolvedNodeConfig {
                 Ok(worker_gas) => {
                     self.system_services.decider.worker_gas = worker_gas;
                     log::warn!(
-                        "Override configuration of decider system spell (worker gas) from ENV"
+                        "Override configuration of decider system spell (worker gas) from ENV to {}", worker_gas
                     );
                 }
                 Err(err) => log::warn!(
@@ -294,7 +312,10 @@ impl UnresolvedNodeConfig {
 
         if let Ok(decider_wallet_key) = std::env::var("FLUENCE_ENV_CONNECTOR_WALLET_KEY") {
             self.system_services.decider.wallet_key = Some(decider_wallet_key);
-            log::warn!("Override configuration of decider system spell (wallet key) from ENV");
+            log::warn!(
+                "Override configuration of decider system spell (wallet key) from ENV to {}",
+                decider_wallet_key
+            );
         }
     }
 }

--- a/crates/system-services/Cargo.toml
+++ b/crates/system-services/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aqua-ipfs-distro = "=0.5.17"
+aqua-ipfs-distro = "=0.5.20"
 decider-distro = "=0.5.1"
 registry-distro = "=0.8.7"
 trust-graph-distro = "=0.4.7"

--- a/crates/system-services/src/distro.rs
+++ b/crates/system-services/src/distro.rs
@@ -142,12 +142,9 @@ pub fn default_aqua_ipfs_distro(config: &AquaIpfsConfig) -> eyre::Result<Package
         let local_api_multiaddr = config.local_api_multiaddr.clone();
         let external_api_multiaddr = config.external_api_multiaddr.clone();
         let init = move |call: &CallService, deployment: DeploymentStatus| {
-            if let Some(status) = deployment.services.get(&name) {
-                let id = match status {
-                    ServiceStatus::Created(id) => id,
-                    ServiceStatus::Existing(id) => id,
-                };
-
+            if let Some(ServiceStatus::Created(id)) | ServiceStatus::Existing(id) =
+                deployment.services.get(&name)
+            {
                 let set_local_result = call(
                     name.clone(),
                     "set_local_api_multiaddr".to_string(),

--- a/crates/system-services/src/distro.rs
+++ b/crates/system-services/src/distro.rs
@@ -142,7 +142,7 @@ pub fn default_aqua_ipfs_distro(config: &AquaIpfsConfig) -> eyre::Result<Package
         let local_api_multiaddr = config.local_api_multiaddr.clone();
         let external_api_multiaddr = config.external_api_multiaddr.clone();
         let init = move |call: &CallService, deployment: DeploymentStatus| {
-            if let Some(ServiceStatus::Created(id)) | ServiceStatus::Existing(id) =
+            if let Some(ServiceStatus::Created(id) | ServiceStatus::Existing(id)) =
                 deployment.services.get(&name)
             {
                 let set_local_result = call(

--- a/crates/system-services/src/distro.rs
+++ b/crates/system-services/src/distro.rs
@@ -142,7 +142,12 @@ pub fn default_aqua_ipfs_distro(config: &AquaIpfsConfig) -> eyre::Result<Package
         let local_api_multiaddr = config.local_api_multiaddr.clone();
         let external_api_multiaddr = config.external_api_multiaddr.clone();
         let init = move |call: &CallService, deployment: DeploymentStatus| {
-            if let Some(ServiceStatus::Created(id)) = deployment.services.get(&name) {
+            if let Some(status) = deployment.services.get(&name) {
+                let id = match status {
+                    ServiceStatus::Created(id) => id,
+                    ServiceStatus::Existing(id) => id,
+                };
+
                 let set_local_result = call(
                     name.clone(),
                     "set_local_api_multiaddr".to_string(),


### PR DESCRIPTION
## Description
Allow to override decider ipfs multiaddr from ENV.

## Motivation
It's necessary to flexibly configure noxes and crucial for local testing setup.

## Proposed Changes
- set decider ipfs multiaddr via `FLUENCE_ENV_DECIDER_IPFS_MULTIADDR
- show overridden values in logs
- bump aqua-ipfs to 0.5.20
- allow to reconfigure aqua-ipfs

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

