### PR TITLE
fix: env configuration loading for protocol config

### DIFF
--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -720,7 +720,7 @@ mod tests {
     }
 
     #[test]
-    fn load_upgrade_timeout() {
+    fn load_env_upgrade_timeout() {
         temp_env::with_vars(
             [("FLUENCE_PROTOCOL_CONFIG__UPGRADE_TIMEOUT", Some("60s"))],
             || {
@@ -732,5 +732,28 @@ mod tests {
                 );
             },
         );
+    }
+
+    #[test]
+    fn load_file_upgrade_timeout() {
+        let mut file = NamedTempFile::new().expect("Could not create temp file");
+        write!(
+            file,
+            r#"
+            [protocol_config]
+            upgrade_timeout = "60s"
+            "#
+        )
+        .expect("Could not write in file");
+
+        let path = file.path().display().to_string();
+
+        temp_env::with_var("FLUENCE_CONFIG", Some(path), || {
+            let config = load_config_with_args(vec![], None).expect("Could not load config");
+            assert_eq!(
+                config.node_config.protocol_config.upgrade_timeout,
+                Duration::from_secs(60)
+            );
+        });
     }
 }

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -226,6 +226,7 @@ pub fn load_config_with_args(
 #[cfg(test)]
 mod tests {
     use std::io::Write;
+    use std::time::Duration;
 
     use base64::{engine::general_purpose::STANDARD as base64, Engine};
     use fluence_keypair::KeyPair;
@@ -716,5 +717,20 @@ mod tests {
                 Some(1001)
             );
         });
+    }
+
+    #[test]
+    fn load_upgrade_timeout() {
+        temp_env::with_vars(
+            [("FLUENCE_PROTOCOL_CONFIG__UPGRADE_TIMEOUT", Some("60s"))],
+            || {
+                let args = vec![];
+                let config = load_config_with_args(args, None).expect("Could not load config");
+                assert_eq!(
+                    config.node_config.protocol_config.upgrade_timeout,
+                    Duration::from_secs(60)
+                );
+            },
+        );
     }
 }

--- a/particle-protocol/src/libp2p_protocol/upgrade.rs
+++ b/particle-protocol/src/libp2p_protocol/upgrade.rs
@@ -36,24 +36,37 @@ use crate::{HandlerMessage, SendStatus, PROTOCOL_NAME};
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct ProtocolConfig {
     /// Timeout for applying the given upgrade on a substream
-    #[serde(with = "humantime_serde")]
+    #[serde(with = "humantime_serde", default = "default_upgrade_timeout")]
     pub upgrade_timeout: Duration,
     /// Keep-alive timeout for idle connections.
-    #[serde(with = "humantime_serde")]
+    #[serde(with = "humantime_serde", default = "default_keep_alive_timeout")]
     pub keep_alive_timeout: Duration,
     /// Timeout for outbound substream upgrades.
-    #[serde(with = "humantime_serde")]
+    #[serde(
+        with = "humantime_serde",
+        default = "default_outbound_substream_timeout"
+    )]
     pub outbound_substream_timeout: Duration,
 }
 
 impl Default for ProtocolConfig {
     fn default() -> Self {
         Self {
-            upgrade_timeout: Duration::from_secs(10),
-            keep_alive_timeout: Duration::from_secs(10),
-            outbound_substream_timeout: Duration::from_secs(10),
+            upgrade_timeout: default_upgrade_timeout(),
+            keep_alive_timeout: default_keep_alive_timeout(),
+            outbound_substream_timeout: default_outbound_substream_timeout(),
         }
     }
+}
+
+fn default_keep_alive_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+fn default_outbound_substream_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+fn default_upgrade_timeout() -> Duration {
+    Duration::from_secs(10)
 }
 
 impl ProtocolConfig {


### PR DESCRIPTION
## Description
Fix protocol config configuration loading from env 

## Motivation
FLUENCE_PROTOCOL_CONFIG__UPGRADE_TIMEOUT doesn't work if another parameters from protocol config wasn't specified

## Related Issue(s)

## Proposed Changes

## Screenshots (if applicable)

## Additional Notes

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

