### PR TITLE
fix(tests): Allow override system services config in tests [NET-576]

### DIFF
--- a/crates/created-swarm/src/lib.rs
+++ b/crates/created-swarm/src/lib.rs
@@ -31,3 +31,5 @@ mod swarm;
 
 pub use crate::services::*;
 pub use crate::swarm::*;
+
+pub use server_config::system_services_config;

--- a/crates/created-swarm/src/swarm.rs
+++ b/crates/created-swarm/src/swarm.rs
@@ -244,6 +244,7 @@ pub struct SwarmConfig {
     pub allowed_binaries: Vec<String>,
     pub enabled_system_services: Vec<String>,
     pub extend_system_services: Vec<system_services::PackageDistro>,
+    pub override_system_services_config: Option<system_services_config::SystemServicesConfig>,
     pub http_port: u16,
     pub connector_api_endpoint: Option<String>,
 }
@@ -267,6 +268,7 @@ impl SwarmConfig {
             allowed_binaries: vec!["/usr/bin/ipfs".to_string(), "/usr/bin/curl".to_string()],
             enabled_system_services: vec![],
             extend_system_services: vec![],
+            override_system_services_config: None,
             http_port: 0,
             connector_api_endpoint: None,
         }
@@ -361,6 +363,11 @@ pub fn create_swarm_with_runtime<RT: AquaRuntime>(
     resolved.node_config.particle_execution_timeout = EXECUTION_TIMEOUT;
 
     resolved.node_config.allowed_binaries = config.allowed_binaries.clone();
+
+    if let Some(config) = config.override_system_services_config.clone() {
+        resolved.system_services = config;
+    }
+    // `enable_system_services` has higher priority then `enable` field of the SystemServicesConfig
     resolved.system_services.enable = config
         .enabled_system_services
         .iter()


### PR DESCRIPTION
## Motivation
IPFS and curl paths can differ in CI, so we need some way to override them. Also, it may be nice to control other configs also.  

## Proposed Changes
Add the `override_system_services_config: Option<SystemServicesConfig>` field in `SwarmConfig`.
Requires importing `server-config` crate to get access to the definition and default values. 
Proposed use:
```rust
make_swarm_with_cfg(1, move |mut cfg| {
   let mut services_cfg = SystemServicesConfig::default();
   services_cfg.aqua_ipfs.ipfs_binary_path = "/new/path/to/ipfs".to_string()
   cfg.override_system_services_config = Some(services_cfg);
   cfg
}) 
```

