### PR TITLE
fix(builtins): validate deal_id in subnet.resolve

### DIFF
--- a/crates/nox-tests/tests/spells.rs
+++ b/crates/nox-tests/tests/spells.rs
@@ -2079,3 +2079,11 @@ async fn set_alias_by_worker_creator() {
         assert_eq!(*resolved, tetraplets_service.id);
     }
 }
+
+// #[tokio::test]
+// fn test_decider_api_endpoint_override() {
+//     let swarms = make_swarms_with_cfg(1, |mut cfg| {
+//         cfg.enabled_system_services = vec!["decider".to_string()];
+//         cfg
+//     });
+// }

--- a/crates/subnet-resolver/src/error.rs
+++ b/crates/subnet-resolver/src/error.rs
@@ -27,4 +27,6 @@ pub enum ResolveSubnetError {
     Empty,
     #[error("'{1}' from getPATs is not a valid PeerId")]
     InvalidPeerId(#[source] ParseError, &'static str),
+    #[error("Invalid deal id '{0}': invalid length")]
+    InvalidDealId(String),
 }

--- a/crates/subnet-resolver/src/resolve.rs
+++ b/crates/subnet-resolver/src/resolve.rs
@@ -35,13 +35,13 @@ pub fn parse_chain_data(data: &str) -> Result<Vec<Token>, ChainDataError> {
     Ok(ethabi::decode(&[signature], &data)?)
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Worker {
     pub pat_id: String,
     pub host_id: String,
     pub worker_id: Vec<String>,
 }
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct SubnetResolveResult {
     pub success: bool,
     pub workers: Vec<Worker>,
@@ -92,8 +92,22 @@ fn decode_pats(data: String) -> Result<Vec<Worker>, ResolveSubnetError> {
     Ok(result)
 }
 
+pub fn validate_deal_id(deal_id: String) -> Result<String, ResolveSubnetError> {
+    let deal_id = if deal_id.starts_with("0x") {
+        deal_id
+    } else {
+        format!("0x{}", deal_id)
+    };
+    // 40 hex chars + 2 for "0x" prefix
+    if deal_id.len() == 40 + 2 {
+        Ok(deal_id)
+    } else {
+        Err(ResolveSubnetError::InvalidDealId(deal_id))
+    }
+}
 pub fn resolve_subnet(deal_id: String, api_endpoint: &str) -> SubnetResolveResult {
     let res: Result<_, ResolveSubnetError> = try {
+        let deal_id = validate_deal_id(deal_id)?;
         // Description of the `getPATs` function from the `chain.workers` smart contract on chain
         #[allow(deprecated)]
         let input = Function {


### PR DESCRIPTION
## Description
Validate deal id in `subnet.resolve`, provide readable error, and append `0x` if necessary

## Motivation
`subnet.resolve` was failing in case of deal_id without `0x` prefix and return unreadable errors in case of invalid deal ids

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

