### PR TITLE
fix(metrics): measure call time and wait time separately

### DIFF
--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -286,7 +286,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
             m.alive_actors.set(self.actors.len() as i64);
 
             for stat in &stats {
-                m.service_call(stat.success, stat.kind, stat.run_time)
+                m.service_call(stat.success, stat.kind, stat.call_time)
             }
         });
 

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -281,9 +281,9 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
 
                 let time = stat.interpretation_time.as_secs_f64();
                 m.interpretation_time_sec.observe(time);
-                m.total_actors_mailbox.set(mailbox_size as i64);
-                m.alive_actors.set(self.actors.len() as i64);
             }
+            m.total_actors_mailbox.set(mailbox_size as i64);
+            m.alive_actors.set(self.actors.len() as i64);
 
             for stat in &stats {
                 m.service_call(stat.success, stat.kind, stat.run_time)

--- a/crates/peer-metrics/src/services_metrics/builtin.rs
+++ b/crates/peer-metrics/src/services_metrics/builtin.rs
@@ -78,6 +78,7 @@ impl Stats {
             ServiceCallStats::Success {
                 memory_delta_bytes,
                 call_time_sec,
+                lock_wait_time_sec: _,
                 timestamp,
             } => {
                 self.memory_deltas_bytes.update(

--- a/crates/peer-metrics/src/services_metrics/external.rs
+++ b/crates/peer-metrics/src/services_metrics/external.rs
@@ -86,7 +86,8 @@ pub struct ServicesMetricsExternal {
     pub modules_in_services_count: Histogram,
 
     /// Service call time
-    pub call_time_msec: Family<ServiceTypeLabel, Histogram>,
+    pub call_time_sec: Family<ServiceTypeLabel, Histogram>,
+    pub lock_wait_time_sec: Family<ServiceTypeLabel, Histogram>,
     pub call_success_count: Family<ServiceTypeLabel, Counter>,
     pub call_failed_count: Family<ServiceTypeLabel, Counter>,
 
@@ -182,11 +183,18 @@ impl ServicesMetricsExternal {
             "number of modules per services",
         );
 
-        let call_time_msec: Family<_, _> = register(
+        let call_time_sec: Family<_, _> = register(
             sub_registry,
             Family::new_with_constructor(|| Histogram::new(execution_time_buckets())),
             "call_time_msec",
             "how long it took to execute a call",
+        );
+
+        let lock_wait_time_sec: Family<_, _> = register(
+            sub_registry,
+            Family::new_with_constructor(|| Histogram::new(execution_time_buckets())),
+            "lock_wait_time_sec",
+            "how long a service waited for Mutex",
         );
 
         let memory_metrics = ServicesMemoryMetrics {
@@ -217,7 +225,8 @@ impl ServicesMetricsExternal {
             removal_count,
             creation_failure_count,
             modules_in_services_count,
-            call_time_msec,
+            call_time_sec,
+            lock_wait_time_sec,
             call_success_count,
             call_failed_count,
             memory_metrics,

--- a/crates/peer-metrics/src/services_metrics/message.rs
+++ b/crates/peer-metrics/src/services_metrics/message.rs
@@ -11,6 +11,7 @@ pub enum ServiceCallStats {
     Success {
         memory_delta_bytes: f64,
         call_time_sec: f64,
+        lock_wait_time_sec: f64,
         timestamp: u64,
     },
     Fail {


### PR DESCRIPTION
## Description
- Report actor mailbox size and actor counts in every poll. Before this PR, it was only reported when there are `interpretation_stats`.
- Measure lock wait time separately from marine execution time in AppService
- Measure time it takes for service call execution to be scheduled on Blocking Pool in Actor
- Separate call execution time measurement from schedule wait time in Actor

## Motivation
Including queuing time from latency measurements skews measurements when system is saturated. In such form, measurement doesn't make much sense: it will obviously grow as more work arrives.

Instead, execution latency should be measured separately, to allow for applying eg Little's Law to estimate system's throughput  at given execution latencies.

Another benefit of that separation is that we get a clear picture of actual Marine performance.

## Concerns

We have two sets of metrics that describe execution latencies. 

One is one the higher level: in Plumber-Actor. It measures Builtin calls latencies as close as possible, which is good. However, for Service Calls its measurements include RWLock and Mutex latencies, which makes these measurements skewed.

To the rescue comes another measurement, lower in the stack, at AppService level. That one (now) measures pure Marine call latency, and time it took to wait for a Service lock to be available.

The mixture of measurement sites and absence of clear naming makes it hard to navigate metrics.

The dashboards in Grafana must be upgraded with great care, then. And documenting these caveats is crucial for external users' ability to observe Nox through these metrics.
