### PR TITLE
feat(nox): add new flags for system services [NET-547, NET-548]

### DIFF
--- a/crates/server-config/src/args.rs
+++ b/crates/server-config/src/args.rs
@@ -240,7 +240,6 @@ impl Serialize for SystemServicesArgs {
                     struct_serializer.serialize_field::<Vec<ServiceKey>>("enable", &vec![])?;
                 }
             }
-            //struct_serializer.serialize_field("generate_on_absence", generate_on_absence)?;
         }
         if let Some(wallet_key) = &self.wallet_key {
             #[derive(Serialize)]

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -786,7 +786,6 @@ where
 
         let alias: String = Args::next("alias", &mut args)?;
         let service_id: String = Args::next("service_id", &mut args)?;
-        log::warn!("add_alias {:?} {:?}", alias, service_id);
         self.services
             .add_alias(alias, params.host_id, service_id, params.init_peer_id)?;
         Ok(())

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -786,6 +786,7 @@ where
 
         let alias: String = Args::next("alias", &mut args)?;
         let service_id: String = Args::next("service_id", &mut args)?;
+        log::warn!("add_alias {:?} {:?}", alias, service_id);
         self.services
             .add_alias(alias, params.host_id, service_id, params.init_peer_id)?;
         Ok(())


### PR DESCRIPTION
## Description

Add two new flags:
- `--wallet-key KEY`
- `--enable-system-services=LIST`
   - `--enable-system-services=all` to enable all available services
   - `--enable-system-services=service1,service2` to enable only services from the list
   - `--enable-system-services=none` to disable all services (disabling now doesn't work, it will be introduce by some other task)

Also, make nox fail when a wallet key isn't set when decider is enabled. 

## Motivation
To be user-friendly

## Additional Notes

These flags are introduced via the existing mechanism of layer configs, so we don't have a lot of control here.
