### PR TITLE
chore(tests): optimization + run heavy test multithreaded

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,6 +19,9 @@ leak-timeout = "100ms"
 filter = 'test(flaky)'
 retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true }
 
+[[profile.default.overrides]]
+filter = 'test(heavy)'
+threads-required = 3
 
 [profile.ci]
 fail-fast = false

--- a/crates/nox-tests/tests/boolean_test.rs
+++ b/crates/nox-tests/tests/boolean_test.rs
@@ -25,13 +25,11 @@ use serde_json::json;
 use connected_client::ConnectedClient;
 use created_swarm::make_swarms;
 use service_modules::load_module;
-use test_constants::KAD_TIMEOUT;
 use test_utils::create_service;
 
 #[tokio::test]
 async fn pass_boolean() {
-    let swarms = make_swarms(3).await;
-    tokio::time::sleep(KAD_TIMEOUT).await;
+    let swarms = make_swarms(1).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await

--- a/crates/nox-tests/tests/echo_particle.rs
+++ b/crates/nox-tests/tests/echo_particle.rs
@@ -16,7 +16,6 @@
 
 use connected_client::ConnectedClient;
 use created_swarm::make_swarms;
-use test_constants::KAD_TIMEOUT;
 
 use eyre::WrapErr;
 use maplit::hashmap;
@@ -24,8 +23,7 @@ use serde_json::json;
 
 #[tokio::test]
 async fn echo_particle() {
-    let swarms = make_swarms(3).await;
-    tokio::time::sleep(KAD_TIMEOUT).await;
+    let swarms = make_swarms(1).await;
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await
         .wrap_err("connect client")

--- a/crates/nox-tests/tests/kademlia.rs
+++ b/crates/nox-tests/tests/kademlia.rs
@@ -22,10 +22,12 @@ use serde_json::{json, Value as JValue};
 
 use connected_client::ConnectedClient;
 use created_swarm::make_swarms;
+use log_utils::enable_logs;
 use particle_protocol::Contact;
 
-#[tokio::test]
-async fn neighborhood() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn neighborhood_heavy() {
+    enable_logs();
     let swarms = make_swarms(3).await;
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await
@@ -63,8 +65,9 @@ async fn neighborhood() {
     }
 }
 
-#[tokio::test]
-async fn neighborhood_with_addresses() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn neighborhood_with_addresses_heavy() {
+    enable_logs();
     let swarms = make_swarms(3).await;
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await

--- a/crates/nox-tests/tests/network/loop_topology.rs
+++ b/crates/nox-tests/tests/network/loop_topology.rs
@@ -23,6 +23,7 @@ use serde_json::Value as JValue;
 
 use connected_client::ConnectedClient;
 use created_swarm::{add_print, make_swarms, CreatedSwarm};
+use log_utils::enable_logs;
 
 use super::join_stream;
 
@@ -255,8 +256,9 @@ async fn fold_fold_fold_seq_two_par_null_folds() {
     assert_eq!(json!(flat), json!(output));
 }
 
-#[tokio::test]
-async fn fold_par_same_node_stream() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fold_par_same_node_stream_heavy() {
+    enable_logs();
     let swarms = make_swarms(3).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
@@ -452,8 +454,8 @@ async fn fold_fold_seq_join() {
     assert_eq!(stream, array);
 }
 
-#[tokio::test]
-async fn fold_fold_pairs_seq_join() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fold_fold_pairs_seq_join_heavy() {
     log_utils::enable_logs();
     let mut swarms = make_swarms(5).await;
 
@@ -597,9 +599,10 @@ async fn fold_seq_join() {
     assert_eq!(can, array);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "client function isn't called when fold ends with null"]
-async fn fold_null_seq_same_node_stream() {
+async fn fold_null_seq_same_node_stream_heavy() {
+    enable_logs();
     let mut swarms = make_swarms(3).await;
 
     add_print(swarms.iter_mut()).await;
@@ -760,8 +763,9 @@ async fn fold_null_seq_same_node_stream() {
     assert_eq!(flat, res);
 }
 
-#[tokio::test]
-async fn fold_via() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fold_via_heavy() {
+    enable_logs();
     let swarms = make_swarms(4).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())

--- a/crates/nox-tests/tests/network/network_explore.rs
+++ b/crates/nox-tests/tests/network/network_explore.rs
@@ -24,6 +24,7 @@ use eyre::{ContextCompat, WrapErr};
 use itertools::Itertools;
 use libp2p::core::Multiaddr;
 use local_vm::read_args;
+use log_utils::enable_logs;
 use maplit::hashmap;
 use serde::Deserialize;
 use serde_json::json;
@@ -66,7 +67,6 @@ pub struct ModuleDescriptor {
 #[tokio::test]
 async fn get_interfaces() {
     let swarms = make_swarms(1).await;
-    tokio::time::sleep(KAD_TIMEOUT).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await
@@ -130,8 +130,7 @@ async fn get_interfaces() {
 
 #[tokio::test]
 async fn get_modules() {
-    let swarms = make_swarms(3).await;
-    tokio::time::sleep(KAD_TIMEOUT).await;
+    let swarms = make_swarms(1).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await
@@ -187,8 +186,7 @@ async fn get_modules() {
 
 #[tokio::test]
 async fn list_blueprints() {
-    let swarms = make_swarms(3).await;
-    tokio::time::sleep(KAD_TIMEOUT).await;
+    let swarms = make_swarms(1).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await
@@ -249,8 +247,9 @@ async fn list_blueprints() {
     assert_eq!(hash.as_str().unwrap(), module_hash);
 }
 
-#[tokio::test]
-async fn explore_services() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explore_services_heavy() {
+    enable_logs();
     let swarms = make_swarms(5).await;
 
     tokio::time::sleep(KAD_TIMEOUT).await;
@@ -336,8 +335,9 @@ async fn explore_services() {
     assert_eq!(external_addrs, expected_addrs);
 }
 
-#[tokio::test]
-async fn explore_services_fixed() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explore_services_fixed_heavy() {
+    enable_logs();
     let swarms = make_swarms(5).await;
     sleep(KAD_TIMEOUT);
 

--- a/crates/nox-tests/tests/tetraplets.rs
+++ b/crates/nox-tests/tests/tetraplets.rs
@@ -25,15 +25,13 @@ use connected_client::ConnectedClient;
 use created_swarm::make_swarms;
 use fluence_app_service::SecurityTetraplet;
 use service_modules::load_module;
-use test_constants::KAD_TIMEOUT;
 use test_utils::create_service;
 
 use eyre::WrapErr;
 
 #[tokio::test]
 async fn test_tetraplets() {
-    let swarms = make_swarms(3).await;
-    tokio::time::sleep(KAD_TIMEOUT).await;
+    let swarms = make_swarms(1).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await

--- a/crates/nox-tests/tests/topology.rs
+++ b/crates/nox-tests/tests/topology.rs
@@ -23,6 +23,7 @@ use serde_json::{json, Value};
 
 use connected_client::ConnectedClient;
 use created_swarm::make_swarms;
+use log_utils::enable_logs;
 use network::join::join_stream;
 use test_constants::KAD_TIMEOUT;
 
@@ -30,8 +31,9 @@ pub mod network {
     pub mod join;
 }
 
-#[tokio::test]
-async fn identity() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn identity_heavy() {
+    enable_logs();
     let swarms = make_swarms(3).await;
     tokio::time::sleep(KAD_TIMEOUT).await;
 
@@ -72,8 +74,9 @@ async fn identity() {
     b.receive().await.wrap_err("receive").unwrap();
 }
 
-#[tokio::test]
-async fn init_peer_id() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn init_peer_id_heavy() {
+    enable_logs();
     let swarms = make_swarms(3).await;
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .await
@@ -101,8 +104,9 @@ async fn init_peer_id() {
     client.receive().await.wrap_err("receive").unwrap();
 }
 
-#[tokio::test]
-async fn join() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn join_heavy() {
+    enable_logs();
     let swarms = make_swarms(3).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())


### PR DESCRIPTION
## Description
Run heavy (swarms >= 3) tests multithreaded, add `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`. Create only 1 swarm if no more is needed.

## Motivation
Some tests periodically fail in ci.

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

