### PR TITLE
fix(metrics): separate a avm call time & interpretation time metrics

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,6 +22,7 @@ retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true }
 [[profile.default.overrides]]
 filter = 'test(heavy)'
 threads-required = 3
+retries = { backoff = "fixed", count = 3, delay = "5s", jitter = true }
 
 [profile.ci]
 fail-fast = false

--- a/aquamarine/src/particle_effects.rs
+++ b/aquamarine/src/particle_effects.rs
@@ -45,6 +45,7 @@ impl ParticleEffects {
 /// Performance stats about particle's interpretation
 pub struct InterpretationStats {
     pub interpretation_time: Duration,
+    pub call_time: Duration,
     pub new_data_len: Option<usize>,
     pub success: bool,
 }

--- a/aquamarine/src/particle_executor.rs
+++ b/aquamarine/src/particle_executor.rs
@@ -108,17 +108,17 @@ impl<RT: AquaRuntime> ParticleExecutor for RT {
                             stats.interpretation_time = outcome.execution_time;
                             let len = new_data_len.map(|l| l as i32).unwrap_or(-1);
                             tracing::trace!(
-                            target: "execution", particle_id = particle.id,
-                            "Particle interpreted in {} [{} bytes => {} bytes]",
-                            pretty(call_time), data_len, len
-                        );
+                                target: "execution", particle_id = particle.id,
+                                "Particle interpreted in {} [{} bytes => {} bytes]",
+                                pretty(call_time), data_len, len
+                            );
                         },
                         Err(err) => {
                             tracing::warn!(
-                            particle_id = particle.id,
-                            "Error executing particle: {}",
-                            err
-                        )
+                                particle_id = particle.id,
+                                "Error executing particle: {}",
+                                err
+                            )
                         }
                     }
 

--- a/aquamarine/src/particle_executor.rs
+++ b/aquamarine/src/particle_executor.rs
@@ -96,7 +96,7 @@ impl<RT: AquaRuntime> ParticleExecutor for RT {
                     let call_time = now.elapsed();
                     let new_data_len = result.as_ref().map(|e| e.data.len()).ok();
                     let mut stats = InterpretationStats {
-                        interpretation_time: Duration::ZERO,  //TODO: here we don't have information for the interpretation time with the error that happened, fix after refactoring AVM::call to AVMRunner::call 
+                        interpretation_time: Duration::ZERO,  // TODO: here we don't have information for the interpretation time with the error that happened, fix after refactoring AVM::call to AVMRunner::call
                         call_time,
                         new_data_len,
                         success: result.is_ok(),

--- a/aquamarine/src/particle_executor.rs
+++ b/aquamarine/src/particle_executor.rs
@@ -96,7 +96,7 @@ impl<RT: AquaRuntime> ParticleExecutor for RT {
                     let call_time = now.elapsed();
                     let new_data_len = result.as_ref().map(|e| e.data.len()).ok();
                     let mut stats = InterpretationStats {
-                        interpretation_time: Duration::ZERO, //TODO: fix after refactoring AVM::call to AVMRunner::call
+                        interpretation_time: Duration::ZERO,  //TODO: here we don't have information for the interpretation time with the error that happened, fix after refactoring AVM::call to AVMRunner::call 
                         call_time,
                         new_data_len,
                         success: result.is_ok(),

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -271,8 +271,10 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
                     m.interpretation_failures.inc();
                 }
 
-                let time = stat.interpretation_time.as_secs_f64();
-                m.interpretation_time_sec.observe(time);
+                let interpretation_time = stat.interpretation_time.as_secs_f64();
+                let call_time = stat.call_time.as_secs_f64();
+                m.interpretation_time_sec.observe(interpretation_time);
+                m.call_time_sec.observe(call_time)
             }
             m.total_actors_mailbox.set(mailbox_size as i64);
             m.alive_actors.set(self.actors.len() as i64);

--- a/crates/peer-metrics/src/particle_executor.rs
+++ b/crates/peer-metrics/src/particle_executor.rs
@@ -48,7 +48,7 @@ impl ParticleExecutorMetrics {
         let call_time_sec = Histogram::new(execution_time_buckets());
         sub_registry.register(
             "avm_call_time_sec",
-            "Distribution of time it took to run the avm call once",
+            "Distribution of time it took to run the avm call (interpretation + saving the particle on disk) once",
             call_time_sec.clone(),
         );
 

--- a/crates/peer-metrics/src/particle_executor.rs
+++ b/crates/peer-metrics/src/particle_executor.rs
@@ -24,6 +24,7 @@ pub struct FunctionKindLabel {
 #[derive(Clone)]
 pub struct ParticleExecutorMetrics {
     pub interpretation_time_sec: Histogram,
+    pub call_time_sec: Histogram,
     pub interpretation_successes: Counter,
     pub interpretation_failures: Counter,
     pub total_actors_mailbox: Gauge,
@@ -42,6 +43,13 @@ impl ParticleExecutorMetrics {
             "interpretation_time_sec",
             "Distribution of time it took to run the interpreter once",
             interpretation_time_sec.clone(),
+        );
+
+        let call_time_sec = Histogram::new(execution_time_buckets());
+        sub_registry.register(
+            "avm_call_time_sec",
+            "Distribution of time it took to run the avm call once",
+            call_time_sec.clone(),
         );
 
         let interpretation_successes = Counter::default();
@@ -93,6 +101,7 @@ impl ParticleExecutorMetrics {
 
         Self {
             interpretation_time_sec,
+            call_time_sec,
             interpretation_successes,
             interpretation_failures,
             total_actors_mailbox,


### PR DESCRIPTION
## Description
Separate an AVM call time & interpretation time metrics.

## Motivation
For now, the interpretation time metric shows as the interpretation time +  disk IO time. We want to expose information without IO to clearly understand the AVM behavior.

## Proposed Changes
interpretation_time becomes time from AVM metrics and shows only interpretation.
call_time is a previous interpretation_time.

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

