### PR TITLE
feat(tracing): add sample rate + filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,6 +4507,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-stdout",
  "opentelemetry_sdk",
  "parking_lot",
  "particle-builtins",
@@ -4740,6 +4741,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
  "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13b2df4cd59c176099ac82806725ba340c8fa7b1a7004c0912daad30470f63e"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -81,8 +81,13 @@ impl FromStr for LogFormat {
 pub enum TracingConfig {
     #[serde(rename = "disabled")]
     Disabled,
+    #[serde(rename = "stdout")]
+    Stdout,
     #[serde(rename = "otlp")]
-    Otlp { endpoint: String },
+    Otlp {
+        endpoint: String,
+        sample_ratio: Option<f64>,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -607,6 +612,7 @@ mod tests {
             [tracing]
             type = "otlp"
             endpoint = "test"
+            sample_ratio = 0.1
             "#
         )
         .expect("Could not write in file");
@@ -618,7 +624,8 @@ mod tests {
             assert_eq!(
                 config.tracing,
                 Some(TracingConfig::Otlp {
-                    endpoint: "test".to_string()
+                    endpoint: "test".to_string(),
+                    sample_ratio: Some(0.1)
                 })
             );
         });
@@ -644,7 +651,8 @@ mod tests {
                 assert_eq!(
                     config.tracing,
                     Some(TracingConfig::Otlp {
-                        endpoint: "test".to_string()
+                        endpoint: "test".to_string(),
+                        sample_ratio: None
                     })
                 );
             },
@@ -684,7 +692,8 @@ mod tests {
             assert_eq!(
                 config.tracing,
                 Some(TracingConfig::Otlp {
-                    endpoint: "test".to_string()
+                    endpoint: "test".to_string(),
+                    sample_ratio: None
                 })
             );
         });

--- a/nox/Cargo.toml
+++ b/nox/Cargo.toml
@@ -64,6 +64,7 @@ tracing-opentelemetry = "0.22.0"
 opentelemetry = "0.21.0"
 opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio-current-thread"] }
 opentelemetry-otlp = "0.14.0"
+opentelemetry-stdout = { version = "0.2.0", features = ["trace"] }
 once_cell = { workspace = true }
 
 [dev-dependencies]

--- a/nox/src/layers.rs
+++ b/nox/src/layers.rs
@@ -4,11 +4,11 @@ use libp2p::PeerId;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::Sampler;
 use opentelemetry_sdk::Resource;
 use server_config::{ConsoleConfig, LogConfig, LogFormat, TracingConfig};
 use std::net::{SocketAddr, ToSocketAddrs};
-use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::level_filters::LevelFilter;
 use tracing::Subscriber;
 use tracing_subscriber::registry::LookupSpan;
@@ -89,7 +89,7 @@ where
 pub fn tracing_layer<S>(
     tracing_config: &Option<TracingConfig>,
     peer_id: PeerId,
-    version: &str
+    version: &str,
 ) -> eyre::Result<Option<impl Layer<S>>>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,

--- a/nox/src/layers.rs
+++ b/nox/src/layers.rs
@@ -1,16 +1,20 @@
 use console_subscriber::ConsoleLayer;
 use eyre::anyhow;
-use opentelemetry::KeyValue;
+use libp2p::PeerId;
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::Sampler;
 use opentelemetry_sdk::Resource;
 use server_config::{ConsoleConfig, LogConfig, LogFormat, TracingConfig};
 use std::net::{SocketAddr, ToSocketAddrs};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing::level_filters::LevelFilter;
 use tracing::Subscriber;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
-pub fn log_layer<S>(log_config: &Option<LogConfig>) -> impl Layer<S>
+pub fn env_filter<S>() -> impl Layer<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
@@ -18,7 +22,7 @@ where
         .unwrap_or_default()
         .replace(char::is_whitespace, "");
 
-    let env_filter = tracing_subscriber::EnvFilter::builder()
+    tracing_subscriber::EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .parse_lossy(rust_log)
         .add_directive("cranelift_codegen=off".parse().unwrap())
@@ -34,8 +38,12 @@ where
         .add_directive("soketto=error".parse().unwrap())
         .add_directive("cranelift_codegen=error".parse().unwrap())
         .add_directive("tracing=error".parse().unwrap())
-        .add_directive("avm_server::runner=error".parse().unwrap());
-
+        .add_directive("avm_server::runner=error".parse().unwrap())
+}
+pub fn log_layer<S>(log_config: &Option<LogConfig>) -> impl Layer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
     let log_format = log_config
         .as_ref()
         .map(|c| &c.format)
@@ -47,12 +55,10 @@ where
             .with_span_path(false)
             .with_span_name(false)
             .layer()
-            .with_filter(env_filter)
             .boxed(),
         LogFormat::Default => tracing_subscriber::fmt::layer()
             .with_thread_ids(true)
             .with_thread_names(true)
-            .with_filter(env_filter)
             .boxed(),
     };
 
@@ -82,6 +88,8 @@ where
 
 pub fn tracing_layer<S>(
     tracing_config: &Option<TracingConfig>,
+    peer_id: PeerId,
+    version: &str
 ) -> eyre::Result<Option<impl Layer<S>>>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
@@ -89,8 +97,36 @@ where
     let tracing_config = tracing_config.as_ref().unwrap_or(&TracingConfig::Disabled);
     let tracing_layer = match tracing_config {
         TracingConfig::Disabled => None,
-        TracingConfig::Otlp { endpoint } => {
-            let resource = Resource::new(vec![KeyValue::new("service.name", "rust-peer")]);
+        TracingConfig::Stdout => {
+            global::set_text_map_propagator(TraceContextPropagator::new());
+            let exporter = opentelemetry_stdout::SpanExporter::default();
+            let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+                .with_simple_exporter(exporter)
+                .build();
+
+            let tracer = provider.tracer("rust-peer");
+
+            let tracing_layer = tracing_opentelemetry::layer::<S>().with_tracer(tracer);
+            Some(tracing_layer)
+        }
+        TracingConfig::Otlp {
+            endpoint,
+            sample_ratio,
+        } => {
+            global::set_text_map_propagator(TraceContextPropagator::new());
+            let resource = Resource::new(vec![
+                KeyValue::new("service.name", "rust-peer"),
+                KeyValue::new("service.version", version.to_string()),
+                KeyValue::new("peer_id", peer_id.to_base58()),
+            ]);
+
+            let mut config = opentelemetry_sdk::trace::config().with_resource(resource);
+
+            if let Some(ratio) = sample_ratio {
+                config = config.with_sampler(Sampler::ParentBased(Box::new(
+                    Sampler::TraceIdRatioBased(*ratio),
+                )));
+            }
 
             let tracer = opentelemetry_otlp::new_pipeline()
                 .tracing()
@@ -99,7 +135,7 @@ where
                         .tonic()
                         .with_endpoint(endpoint),
                 )
-                .with_trace_config(opentelemetry_sdk::trace::config().with_resource(resource))
+                .with_trace_config(config)
                 .install_batch(opentelemetry_sdk::runtime::TokioCurrentThread)?;
 
             let tracing_layer = tracing_opentelemetry::layer::<S>().with_tracer(tracer);

--- a/nox/src/lib.rs
+++ b/nox/src/lib.rs
@@ -55,6 +55,7 @@ pub use node::Node;
 pub use connection_pool::Command as ConnectionPoolCommand;
 pub use connectivity::Connectivity;
 pub use kademlia::Command as KademliaCommand;
+pub use layers::env_filter;
 pub use layers::log_layer;
 pub use layers::tokio_console_layer;
 pub use layers::tracing_layer;

--- a/nox/src/main.rs
+++ b/nox/src/main.rs
@@ -29,6 +29,7 @@
 use base64::{engine::general_purpose::STANDARD as base64, Engine};
 
 use eyre::WrapErr;
+use libp2p::PeerId;
 use tokio::signal;
 use tokio::sync::oneshot;
 use tracing_subscriber::layer::SubscriberExt;
@@ -38,7 +39,7 @@ use air_interpreter_fs::write_default_air_interpreter;
 use aquamarine::{VmConfig, AVM};
 use config_utils::to_peer_id;
 use fs_utils::to_abs_path;
-use nox::{log_layer, tokio_console_layer, tracing_layer, Node};
+use nox::{env_filter, log_layer, tokio_console_layer, tracing_layer, Node};
 use server_config::{load_config, ConfigData, ResolvedConfig};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -105,23 +106,32 @@ fn main() -> eyre::Result<()> {
         .build()
         .expect("Could not make tokio runtime")
         .block_on(async {
-            tracing_subscriber::registry()
-                .with(log_layer(&config.log))
-                .with(tokio_console_layer(&config.console)?)
-                .with(tracing_layer(&config.tracing)?)
-                .init();
-
             if let Some(true) = config.print_config {
                 log::info!("Loaded config: {:#?}", config);
             }
 
-            let config = config.resolve()?;
+            let resolver_config = config.clone().resolve()?;
 
-            let interpreter_path = to_abs_path(config.dir_config.air_interpreter_path.clone());
+            let key_pair = resolver_config.node_config.root_key_pair.clone();
+            let base64_key_pair = base64.encode(key_pair.public().to_vec());
+            let peer_id = to_peer_id(&key_pair.into());
+
+            tracing_subscriber::registry()
+                .with(env_filter())
+                .with(log_layer(&config.log))
+                .with(tokio_console_layer(&config.console)?)
+                .with(tracing_layer(&config.tracing, peer_id, VERSION)?)
+                .init();
+
+            log::info!("node public key = {}", base64_key_pair);
+            log::info!("node server peer id = {}", peer_id);
+
+            let interpreter_path =
+                to_abs_path(resolver_config.dir_config.air_interpreter_path.clone());
             write_default_air_interpreter(&interpreter_path)?;
             log::info!("AIR interpreter: {:?}", interpreter_path);
 
-            let fluence = start_fluence(config).await?;
+            let fluence = start_fluence(resolver_config, peer_id).await?;
             log::info!("Fluence has been successfully started.");
             log::info!("Waiting for Ctrl-C to exit...");
 
@@ -134,14 +144,8 @@ fn main() -> eyre::Result<()> {
 }
 
 // NOTE: to stop Fluence just call Stoppable::stop()
-async fn start_fluence(config: ResolvedConfig) -> eyre::Result<impl Stoppable> {
+async fn start_fluence(config: ResolvedConfig, peer_id: PeerId) -> eyre::Result<impl Stoppable> {
     log::trace!("starting Fluence");
-
-    let key_pair = config.root_key_pair.clone();
-    let base64_key_pair = base64.encode(key_pair.public().to_vec());
-    let peer_id = to_peer_id(&key_pair.into());
-    log::info!("node public key = {}", base64_key_pair);
-    log::info!("node server peer id = {}", peer_id);
 
     let listen_addrs = config.listen_multiaddrs();
     let vm_config = vm_config(&config);


### PR DESCRIPTION
## Description
Added a sample rate to the otlp config. 

## Motivation
For now, we don't have a sampler configuration. To reduce pressure on the tracing collector I have added an additional property into the configuration.

## Related Issue(s)
[https://linear.app/fluence/issue/NET-631/improve-otlp-tracing-config](https://linear.app/fluence/issue/NET-631/improve-otlp-tracing-config)

## Proposed Changes
- Added a config for sampler
- Env filter becomes the separate layer to reduce the event count for the tracing subscriber


## Additional Notes
- Added peer_id to the tracing layer for better understanding in the tracing viewer.
- Added stdout tracing output for the devs

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

