### PR TITLE
feat(config): add multiple file config sources

### DIFF
--- a/crates/peer-metrics/Cargo.toml
+++ b/crates/peer-metrics/Cargo.toml
@@ -11,7 +11,7 @@ fluence-app-service = { workspace = true }
 fluence-libp2p = { workspace = true }
 particle-execution = { workspace = true }
 
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "tracing"] }
 tokio-stream = { workspace = true }
 futures = { workspace = true }
 serde = { version = "1.0.192", features = ["derive"] }

--- a/crates/server-config/Cargo.toml
+++ b/crates/server-config/Cargo.toml
@@ -15,7 +15,6 @@ fluence-keypair = { workspace = true }
 log = "0.4.20"
 toml = "0.7.3"
 
-
 libp2p = { workspace = true }
 libp2p-metrics = { workspace = true }
 libp2p-connection-limits = { workspace = true }

--- a/crates/server-config/src/args.rs
+++ b/crates/server-config/src/args.rs
@@ -359,14 +359,14 @@ pub(crate) struct DerivedArgs {
 
     #[arg(
         short('c'),
-        long,
+        long("config"),
         id = "CONFIG_FILE",
         help_heading = "Node configuration",
         help = "TOML configuration file",
         value_name = "PATH",
         display_order = 15
     )]
-    pub(crate) config: Option<PathBuf>,
+    pub(crate) configs: Option<Vec<PathBuf>>,
     #[arg(
         short('d'),
         long,

--- a/crates/server-config/src/args.rs
+++ b/crates/server-config/src/args.rs
@@ -368,7 +368,10 @@ pub(crate) struct DerivedArgs {
         The argument can by used multiple times. \
         The last configuration overrides the previous ones.",
         value_name = "PATH",
-        display_order = 15
+        num_args(1..),
+        value_delimiter(','),
+        display_order = 15,
+
     )]
     pub(crate) configs: Option<Vec<PathBuf>>,
     #[arg(

--- a/crates/server-config/src/args.rs
+++ b/crates/server-config/src/args.rs
@@ -363,6 +363,10 @@ pub(crate) struct DerivedArgs {
         id = "CONFIG_FILE",
         help_heading = "Node configuration",
         help = "TOML configuration file",
+        long_help = "TOML configuration file. If not specified, the default configuration is used. \
+        If specified, the default configuration is merged with the specified one. \
+        The argument can by used multiple times. \
+        The last configuration overrides the previous ones.",
         value_name = "PATH",
         display_order = 15
     )]

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -164,10 +164,6 @@ pub fn default_execution_timeout() -> Duration {
     Duration::from_secs(20)
 }
 
-pub fn default_autodeploy_retry_attempts() -> u16 {
-    5
-}
-
 pub fn default_processing_timeout() -> Duration {
     Duration::from_secs(120)
 }

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -54,11 +54,6 @@ pub fn default_connection_idle_timeout() -> Duration {
 pub fn default_max_established_per_peer_limit() -> Option<u32> {
     Some(5)
 }
-
-pub fn default_auto_particle_ttl() -> Duration {
-    Duration::from_secs(200)
-}
-
 pub fn default_bootstrap_nodes() -> Vec<Multiaddr> {
     vec![]
 }

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -424,9 +424,6 @@ pub struct ListenConfig {
     /// For ws connections
     #[serde(default = "default_websocket_port")]
     pub websocket_port: u16,
-
-    #[serde(default)]
-    pub listen_multiaddrs: Vec<Multiaddr>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -35,19 +35,6 @@ pub struct UnresolvedNodeConfig {
     #[serde(default)]
     pub builtins_key_pair: Option<KeypairConfig>,
 
-    /// Particle ttl for autodeploy
-    #[serde(default = "default_auto_particle_ttl")]
-    #[serde(with = "humantime_serde")]
-    pub autodeploy_particle_ttl: Duration,
-
-    /// Configure the number of ping attempts to check the readiness of the vm pool.
-    /// Total wait time is the autodeploy_particle_ttl times the number of attempts.
-    #[serde(default = "default_autodeploy_retry_attempts")]
-    pub autodeploy_retry_attempts: u16,
-
-    /// Affects builtins autodeploy. If set to true, then all builtins should be recreated and their state is cleaned up.
-    #[serde(default)]
-    pub force_builtins_redeploy: bool,
 
     #[serde(flatten)]
     pub transport_config: TransportConfig,
@@ -188,10 +175,6 @@ impl UnresolvedNodeConfig {
             allow_local_addresses: self.allow_local_addresses,
             particle_execution_timeout: self.particle_execution_timeout,
             management_peer_id: self.management_peer_id,
-
-            autodeploy_particle_ttl: self.autodeploy_particle_ttl,
-            autodeploy_retry_attempts: self.autodeploy_retry_attempts,
-            force_builtins_redeploy: self.force_builtins_redeploy,
             transport_config: self.transport_config,
             listen_config: self.listen_config,
             allowed_binaries,
@@ -304,16 +287,6 @@ pub struct NodeConfig {
 
     #[derivative(Debug = "ignore")]
     pub builtins_key_pair: KeyPair,
-
-    /// Particle ttl for autodeploy
-    pub autodeploy_particle_ttl: Duration,
-
-    /// Configure the number of ping attempts to check the readiness of the vm pool.
-    /// Total wait time is the autodeploy_particle_ttl times the number of attempts.
-    pub autodeploy_retry_attempts: u16,
-
-    /// Affects builtins autodeploy. If set to true, then all builtins should be recreated and their state is cleaned up.
-    pub force_builtins_redeploy: bool,
 
     pub transport_config: TransportConfig,
 

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -35,7 +35,6 @@ pub struct UnresolvedNodeConfig {
     #[serde(default)]
     pub builtins_key_pair: Option<KeypairConfig>,
 
-
     #[serde(flatten)]
     pub transport_config: TransportConfig,
 

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -867,7 +867,7 @@ mod tests {
                     ]
                 );
                 assert_eq!(config.node_config.listen_config.websocket_port, 666);
-                assert_eq!(config.node_config.aquavm_pool_size, 16);
+                assert_eq!(config.node_config.aquavm_pool_size, 160);
             },
         );
     }

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -174,7 +174,7 @@ pub struct ConfigData {
 
 /// Hierarchically loads the configuration using args and envs.
 /// The source order is:
-///  - Load and parse config.toml nearest binary (not required file)
+///  - Load and parse config.toml from cwd (not required file)
 ///  - Load and parse files provided by FLUENCE_CONFIG env var
 ///  - Load and parse files provided by --config arg
 ///  - Load config values from env vars

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -178,7 +178,7 @@ pub struct ConfigData {
 ///  - Load and parse files provided by FLUENCE_CONFIG env var
 ///  - Load and parse files provided by --config arg
 ///  - Load config values from env vars
-///  - Load config values from args
+///  - Load config values from args (throw error on conflicts with env vars)
 /// On each stage the values override the previous ones.
 ///
 /// # Arguments

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -240,13 +240,10 @@ pub fn load_config_with_args(
         config_builder = config_builder.add_source(source)
     }
 
-    config_builder = config_builder.add_source(env_source);
-
     for source in arg_config_sources {
         config_builder = config_builder.add_source(source)
     }
-
-    config_builder = config_builder.add_source(arg_source);
+    config_builder = config_builder.add_source(env_source).add_source(arg_source);
     let config = config_builder.build()?;
 
     let config: UnresolvedConfig = config.try_deserialize()?;

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -174,7 +174,7 @@ pub struct ConfigData {
 
 /// Hierarchically loads the configuration using args and envs.
 /// The source order is:
-///  - Load and parse config.toml from cwd (not required file)
+///  - Load and parse Config.toml from cwd, if exists
 ///  - Load and parse files provided by FLUENCE_CONFIG env var
 ///  - Load and parse files provided by --config arg
 ///  - Load config values from env vars

--- a/nox/src/main.rs
+++ b/nox/src/main.rs
@@ -106,10 +106,6 @@ fn main() -> eyre::Result<()> {
         .build()
         .expect("Could not make tokio runtime")
         .block_on(async {
-            if let Some(true) = config.print_config {
-                log::info!("Loaded config: {:#?}", config);
-            }
-
             let resolver_config = config.clone().resolve()?;
 
             let key_pair = resolver_config.node_config.root_key_pair.clone();
@@ -122,6 +118,10 @@ fn main() -> eyre::Result<()> {
                 .with(tokio_console_layer(&config.console)?)
                 .with(tracing_layer(&config.tracing, peer_id, VERSION)?)
                 .init();
+
+            if let Some(true) = config.print_config {
+                log::info!("Loaded config: {:#?}", config);
+            }
 
             log::info!("node public key = {}", base64_key_pair);
             log::info!("node server peer id = {}", peer_id);


### PR DESCRIPTION
## Description
Allow to pass --config argument multiple times and allow to pass multiple paths in FLUENCE_CONFIG env.

## Motivation
Want to have a layered configuration: define based things in one file and override them with another config.

## Related Issue(s)
[https://linear.app/fluence/issue/NET-594/add-option-to-nox-cli-to-consume-several-configtomls](https://linear.app/fluence/issue/NET-594/add-option-to-nox-cli-to-consume-several-configtomls)
[https://linear.app/fluence/issue/NET-616/remove-unused-options-in-nox-config](https://linear.app/fluence/issue/NET-616/remove-unused-options-in-nox-config)

## Proposed Changes
The initial file for loading is a Config.toml located near the nox binary file but it is not required.
The second priority is all files from FLUENCE_CONFIG env, separated by comma (,)
The last priority is files passed by the --config argument. The last config has the higher priority and overrides provided values from previous configs. All files provided by FLUENCE_CONFIG and --config should exist.


## Additional Notes
Also removed unused values in configs.

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

