### PR TITLE
chore(deps): update decider-distro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "decider-distro"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dd3dc1469b9b64ba95a8c58b9069e2b3e4b4bb5302b1f420cd2381f27ce40f"
+checksum = "2222e93a91a282fb033c64f39b0e8a118f15afbc63bed1f0acb76f2b76bd80ef"
 dependencies = [
  "built 0.7.1",
  "fluence-spell-dtos",

--- a/crates/system-services/Cargo.toml
+++ b/crates/system-services/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 aqua-ipfs-distro = "=0.5.24"
-decider-distro = "=0.5.5"
+decider-distro = "=0.5.6"
 registry-distro = "=0.9.0"
 trust-graph-distro = "=0.4.7"
 


### PR DESCRIPTION
For some reason, the renovate bot didn't create a PR for this, so I do