### PR TITLE
fix(cleanup): cleanup par + max batch size

### DIFF
--- a/aquamarine/src/actor.rs
+++ b/aquamarine/src/actor.rs
@@ -81,7 +81,6 @@ where
         data_store: Arc<ParticleDataStore>,
         deal_id: Option<String>,
     ) -> Self {
-        let particle = particle;
         Self {
             deadline: Deadline::from(particle),
             functions,

--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -27,6 +27,7 @@ use tracing::instrument;
 
 use now_millis::now_ms;
 use particle_execution::{ParticleVault, VaultError};
+use thiserror::Error;
 
 type Result<T> = std::result::Result<T, DataStoreError>;
 

--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -27,7 +27,6 @@ use tracing::instrument;
 
 use now_millis::now_ms;
 use particle_execution::{ParticleVault, VaultError};
-use thiserror::Error;
 
 type Result<T> = std::result::Result<T, DataStoreError>;
 

--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use avm_server::avm_runner::RawAVMOutcome;
 use avm_server::{AnomalyData, CallResults, ParticleParameters};
 use fluence_libp2p::PeerId;
+use futures::{future, FutureExt};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -106,24 +107,29 @@ impl ParticleDataStore {
     }
 
     pub async fn batch_cleanup_data(&self, data: Vec<(String, PeerId)>) {
-        for (particle_id, peer_id) in data {
-            tracing::debug!(
-                target: "particle_reap",
-                particle_id = particle_id, worker_id = peer_id.to_string(),
-                "Reaping particle's actor"
-            );
-
-            if let Err(err) = self
-                .cleanup_data(particle_id.as_str(), peer_id.to_string().as_str())
-                .await
-            {
-                tracing::warn!(
-                    particle_id = particle_id,
-                    "Error cleaning up after particle {:?}",
-                    err
+        future::join_all(data.into_iter().map(|(particle_id, peer_id)| {
+            async move {
+                let peer_id = peer_id.to_string();
+                tracing::debug!(
+                    target: "particle_reap",
+                    particle_id = particle_id, worker_id = peer_id,
+                    "Reaping particle's actor"
                 );
+
+                if let Err(err) = self
+                    .cleanup_data(particle_id.as_str(), peer_id.as_str())
+                    .await
+                {
+                    tracing::warn!(
+                        particle_id = particle_id,
+                        "Error cleaning up after particle {:?}",
+                        err
+                    );
+                }
             }
-        }
+            .boxed()
+        }))
+        .await;
     }
 
     async fn cleanup_data(&self, particle_id: &str, current_peer_id: &str) -> Result<()> {

--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -107,8 +107,8 @@ impl ParticleDataStore {
         Ok(data)
     }
 
-    pub async fn batch_cleanup_data(&self, data: Vec<(String, PeerId)>) {
-        let futures: FuturesUnordered<_> = data
+    pub async fn batch_cleanup_data(&self, cleanup_keys: Vec<(String, PeerId)>) {
+        let futures: FuturesUnordered<_> = cleanup_keys
             .into_iter()
             .map(|(particle_id, peer_id)| async move {
                 let peer_id = peer_id.to_string();

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -132,7 +132,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
         let builtins = &self.builtins;
         let key = ActorKey {
             signature: particle.particle.signature.clone(),
-            worker_id: worker_id,
+            worker_id,
         };
         let entry = self.actors.entry(key);
 

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -52,7 +52,7 @@ use crate::ParticleDataStore;
 #[derive(PartialEq, Hash, Eq)]
 struct ActorKey {
     signature: Vec<u8>,
-    peer_id: PeerId,
+    worker_id: PeerId,
 }
 
 const MAX_CLEANUP_KEYS_SIZE: usize = 1024;
@@ -132,7 +132,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
         let builtins = &self.builtins;
         let key = ActorKey {
             signature: particle.particle.signature.clone(),
-            peer_id: worker_id,
+            worker_id: worker_id,
         };
         let entry = self.actors.entry(key);
 

--- a/nox/src/effectors.rs
+++ b/nox/src/effectors.rs
@@ -51,7 +51,7 @@ impl Effectors {
             async move {
                 // resolve contact
                 if let Some(contact) = connectivity
-                    .resolve_contact(target, &particle.as_ref())
+                    .resolve_contact(target, particle.as_ref())
                     .await
                 {
                     // forward particle


### PR DESCRIPTION
## Description
In this PR we fix the count of cleanup batch and parallelize deletion.

## Motivation
If cleanup is slow it dramatically decreases the whole system performance. 

## Proposed Changes
- Make a cleanup batch smaller 
- Parallelize deletion

## Additional Notes
- Now par delete isn't limited by parallel factor, it means if the batch size is 1024 it will produce 1024 tasks and try to run them in parallel. As a result, it will spawn a lot of tasks on the blocking poll which utilize them fully, but it is ok.
- Also introduced an ActorKey which should be used as a datastore key in [NET-632](https://linear.app/fluence/issue/NET-632/use-particlesignature-instead-of-particleid-in-data-store)

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

