### PR TITLE
feat(plumber): allow root to access deactivated workers [fixes NET-695]

### DIFF
--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -120,6 +120,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
             && !self
                 .key_manager
                 .is_management(particle.particle.init_peer_id)
+            && !self.key_manager.is_host(particle.particle.init_peer_id)
         {
             tracing::trace!(target: "worker_inactive", particle_id = particle.particle.id, worker_id = worker_id.to_string(), "Worker is not active");
             return;

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -117,12 +117,13 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
         }
 
         let is_active = self.key_manager.is_worker_active(worker_id);
-        let is_manager = self.key_manager.is_management(particle.particle.init_peer_id);
+        let is_manager = self
+            .key_manager
+            .is_management(particle.particle.init_peer_id);
         let is_host = self.key_manager.is_host(particle.particle.init_peer_id);
 
         // Only a manager or the host itself is allowed to access deactivated workers
-        if !is_active  && !is_manager && !is_host
-        {
+        if !is_active && !is_manager && !is_host {
             tracing::trace!(target: "worker_inactive", particle_id = particle.particle.id, worker_id = worker_id.to_string(), "Worker is not active");
             return;
         }

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -116,11 +116,12 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
             return;
         }
 
-        if !self.key_manager.is_worker_active(worker_id)
-            && !self
-                .key_manager
-                .is_management(particle.particle.init_peer_id)
-            && !self.key_manager.is_host(particle.particle.init_peer_id)
+        let is_active = self.key_manager.is_worker_active(worker_id);
+        let is_manager = self.key_manager.is_management(particle.particle.init_peer_id);
+        let is_host = self.key_manager.is_host(particle.particle.init_peer_id);
+
+        // Only a manager or the host itself is allowed to access deactivated workers
+        if !is_active  && !is_manager && !is_host
         {
             tracing::trace!(target: "worker_inactive", particle_id = particle.particle.id, worker_id = worker_id.to_string(), "Worker is not active");
             return;


### PR DESCRIPTION
## Description
Allow root to access deactivated workers.

## Motivation
Decider needs to be able to update the worker spell's KV even if the worker is deactivated. 

