### PR TITLE
fix(config): respect base_dir in keypair generation

### DIFF
--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -18,7 +18,6 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use fluence_keypair::KeyPair;
 use libp2p::core::Multiaddr;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::identity::PublicKey;
@@ -26,7 +25,7 @@ use libp2p::PeerId;
 
 use fluence_libp2p::Transport;
 
-use crate::node_config::{KeypairConfig, PathOrValue};
+use crate::node_config::PathOrValue;
 use crate::system_services_config::ServiceKey;
 
 const CONFIG_VERSION: usize = 1;
@@ -95,44 +94,16 @@ pub fn avm_base_dir(base_dir: &Path) -> PathBuf {
     base_dir.join("stepper")
 }
 
-pub fn default_keypair_path() -> PathOrValue {
+pub fn default_keypair_path(base_dir: &Path) -> PathOrValue {
     PathOrValue::Path {
-        path: default_base_dir().join("secret_key.ed25519"),
+        path: base_dir.join("secret_key.ed25519"),
     }
 }
 
-pub fn default_builtins_keypair_path() -> PathOrValue {
+pub fn default_builtins_keypair_path(base_dir: &Path) -> PathOrValue {
     PathOrValue::Path {
-        path: default_base_dir().join("builtins_secret_key.ed25519"),
+        path: base_dir.join("builtins_secret_key.ed25519"),
     }
-}
-
-pub fn default_root_keypair() -> KeyPair {
-    let config = KeypairConfig {
-        format: default_key_format(),
-        keypair: None,
-        secret_key: None,
-        generate_on_absence: true,
-    };
-
-    config
-        // TODO: respect base_dir https://github.com/fluencelabs/fluence/issues/1210
-        .get_keypair(default_keypair_path())
-        .expect("generate default root keypair")
-}
-
-pub fn default_builtins_keypair() -> KeyPair {
-    let config = KeypairConfig {
-        format: default_key_format(),
-        keypair: None,
-        secret_key: None,
-        generate_on_absence: true,
-    };
-
-    config
-        // TODO: respect base_dir https://github.com/fluencelabs/fluence/issues/1210
-        .get_keypair(default_builtins_keypair_path())
-        .expect("generate default builtins keypair")
 }
 
 pub fn default_aquavm_pool_size() -> usize {

--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use base64::{engine::general_purpose::STANDARD as base64, Engine};
@@ -132,7 +132,7 @@ pub struct UnresolvedNodeConfig {
 }
 
 impl UnresolvedNodeConfig {
-    pub fn resolve(mut self) -> eyre::Result<NodeConfig> {
+    pub fn resolve(mut self, base_dir: &Path) -> eyre::Result<NodeConfig> {
         self.load_system_services_envs();
 
         let bootstrap_nodes = match self.local {
@@ -143,12 +143,12 @@ impl UnresolvedNodeConfig {
         let root_key_pair = self
             .root_key_pair
             .unwrap_or_default()
-            .get_keypair(default_keypair_path())?;
+            .get_keypair(default_keypair_path(base_dir))?;
 
         let builtins_key_pair = self
             .builtins_key_pair
             .unwrap_or_default()
-            .get_keypair(default_builtins_keypair_path())?;
+            .get_keypair(default_builtins_keypair_path(base_dir))?;
 
         let mut allowed_binaries = self.allowed_binaries;
         allowed_binaries.push(self.system_services.aqua_ipfs.ipfs_binary_path.clone());

--- a/crates/server-config/src/resolved_config.rs
+++ b/crates/server-config/src/resolved_config.rs
@@ -46,9 +46,12 @@ pub struct UnresolvedConfig {
 
 impl UnresolvedConfig {
     pub fn resolve(self) -> eyre::Result<ResolvedConfig> {
+        let node_config = self.node_config.resolve(&self.dir_config.base_dir)?;
+        let dir_config = self.dir_config.resolve()?;
+
         Ok(ResolvedConfig {
-            dir_config: self.dir_config.resolve()?,
-            node_config: self.node_config.resolve()?,
+            dir_config,
+            node_config,
         })
     }
 }


### PR DESCRIPTION
## Description

@nahsi asked:
> Can we make nox to put keys to `BASE_DIR/...` by default instead of `/.fluence`?

It turns out, the current keypair generation does not respect `base_dir` property in config. It always uses `/.fluence` as a base dir, and puts key there.

## Proposed Changes

Load and store keypairs relative to base_dir in Nox config.

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

