### PR TITLE
feat(workers): Create a ThreadPool for each worker [fixes NET-688]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "config",
  "config-utils",
  "control-macro",
+ "enum_dispatch",
  "eyre",
  "fluence-keypair",
  "fluence-libp2p",
@@ -1836,6 +1837,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+dependencies = [
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "workers",
 ]
@@ -7403,6 +7404,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.2",
  "pin-project-lite",
  "tokio",
  "tracing",

--- a/aquamarine/Cargo.toml
+++ b/aquamarine/Cargo.toml
@@ -41,6 +41,7 @@ bytesize = "1.3.0"
 async-trait = "0.1.74"
 health = { workspace = true }
 config = { version = "0.13.4", features = [] }
+enum_dispatch = "0.3.12"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/aquamarine/Cargo.toml
+++ b/aquamarine/Cargo.toml
@@ -28,6 +28,7 @@ log = { workspace = true }
 
 tokio = { workspace = true, features = ["fs", "rt"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/aquamarine/src/actor.rs
+++ b/aquamarine/src/actor.rs
@@ -66,7 +66,7 @@ pub struct Actor<RT, F> {
     current_peer_id: PeerId,
     key_pair: KeyPair,
     data_store: Arc<ParticleDataStore>,
-    handle: Handle,
+    runtime_handle: Handle,
     deal_id: Option<String>,
 }
 
@@ -81,7 +81,7 @@ where
         current_peer_id: PeerId,
         key_pair: KeyPair,
         data_store: Arc<ParticleDataStore>,
-        handle: Handle,
+        runtime_handle: Handle,
         deal_id: Option<String>,
     ) -> Self {
         Self {
@@ -98,7 +98,7 @@ where
             current_peer_id,
             key_pair,
             data_store,
-            handle,
+            runtime_handle,
             deal_id,
         }
     }
@@ -163,7 +163,7 @@ where
             let waker = cx.waker().clone();
             // Schedule execution of functions
             self.functions.execute(
-                self.handle.clone(),
+                self.runtime_handle.clone(),
                 self.particle.id.clone(),
                 effects.call_requests,
                 waker,
@@ -226,7 +226,7 @@ where
 
         let waker = cx.waker().clone();
         let data_store = self.data_store.clone();
-        let handle = self.handle.clone();
+        let handle = self.runtime_handle.clone();
         let key_pair = self.key_pair.clone();
         let peer_id = self.current_peer_id;
 
@@ -252,7 +252,7 @@ where
                         (reusables, res.effects, res.stats, linking_span)
                     })
                     .await
-                    .expect("Failed to shift execution to handle")
+                    .expect(" Failed to shift execution to handle")
             }
             .instrument(async_span)
             .boxed(),

--- a/aquamarine/src/actor.rs
+++ b/aquamarine/src/actor.rs
@@ -162,15 +162,13 @@ where
             let spawner = self.spawner.clone();
             let waker = cx.waker().clone();
             // Schedule execution of functions
-            {
-                self.functions.execute(
-                    spawner,
-                    self.particle.id.clone(),
-                    effects.call_requests,
-                    waker,
-                    parent_span.clone(),
-                );
-            }
+            self.functions.execute(
+                spawner,
+                self.particle.id.clone(),
+                effects.call_requests,
+                waker,
+                parent_span.clone(),
+            );
 
             let effects = RoutingEffects {
                 particle: ExtendedParticle::linked(

--- a/aquamarine/src/aquamarine.rs
+++ b/aquamarine/src/aquamarine.rs
@@ -29,7 +29,7 @@ use health::HealthCheckRegistry;
 use particle_execution::{ParticleFunctionStatic, ServiceFunction};
 use particle_protocol::ExtendedParticle;
 use peer_metrics::{ParticleExecutorMetrics, VmPoolMetrics};
-use workers::{Scope, Workers};
+use workers::{PeerScope, Workers};
 
 use crate::aqua_runtime::AquaRuntime;
 use crate::command::Command;
@@ -61,7 +61,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> AquamarineBackend<RT, F> {
         vm_pool_metrics: Option<VmPoolMetrics>,
         health_registry: Option<&mut HealthCheckRegistry>,
         workers: Arc<Workers>,
-        scope: Scope,
+        scope: PeerScope,
     ) -> eyre::Result<(Self, AquamarineApi)> {
         // TODO: make `100` configurable
         let (outlet, inlet) = mpsc::channel(100);

--- a/aquamarine/src/lib.rs
+++ b/aquamarine/src/lib.rs
@@ -52,4 +52,5 @@ mod particle_effects;
 mod particle_executor;
 mod particle_functions;
 mod plumber;
+mod spawner;
 mod vm_pool;

--- a/aquamarine/src/particle_executor.rs
+++ b/aquamarine/src/particle_executor.rs
@@ -86,8 +86,14 @@ impl<RT: AquaRuntime> ParticleExecutor for RT {
         let particle_id = particle.id.clone();
         tracing::trace!(target: "execution", particle_id = particle_id, "Executing particle");
 
-        let prev_data = data_store
-            .read_data(particle_id.as_str(), current_peer_id.to_base58().as_str())
+        let io_data_store = data_store.clone();
+        let prev_data = spawner
+            .spawn_io(async move {
+                io_data_store
+                    .clone()
+                    .read_data(particle_id.as_str(), current_peer_id.to_base58().as_str())
+                    .await
+            })
             .await;
 
         if let Ok(prev_data) = prev_data {

--- a/aquamarine/src/particle_executor.rs
+++ b/aquamarine/src/particle_executor.rs
@@ -241,7 +241,7 @@ async fn avm_call<'a, RT: AquaRuntime>(
     call_results: CallResults,
     prev_data: Vec<u8>,
 ) -> Result<AVMCallResult<'a, RT>, JoinError> {
-    tokio::task::spawn_blocking(move || {
+    tokio::task::spawn(async move {
         let particle_id = particle.id.clone();
         let now = Instant::now();
         let memory_size_before = vm.memory_stats().memory_size;

--- a/aquamarine/src/particle_executor.rs
+++ b/aquamarine/src/particle_executor.rs
@@ -86,14 +86,9 @@ impl<RT: AquaRuntime> ParticleExecutor for RT {
         let particle_id = particle.id.clone();
         tracing::trace!(target: "execution", particle_id = particle_id, "Executing particle");
 
-        let io_data_store = data_store.clone();
-        let prev_data = spawner
-            .spawn_io(async move {
-                io_data_store
-                    .clone()
-                    .read_data(particle_id.as_str(), current_peer_id.to_base58().as_str())
-                    .await
-            })
+        let prev_data = data_store
+            .clone()
+            .read_data(particle_id.as_str(), current_peer_id.to_base58().as_str())
             .await;
 
         if let Ok(prev_data) = prev_data {
@@ -133,7 +128,7 @@ async fn execute_with_prev_data<RT: AquaRuntime>(
     let prev_data_len = prev_data.len();
 
     let avm_result = avm_call(
-        spawner.clone(),
+        spawner,
         vm,
         current_peer_id,
         key_pair,

--- a/aquamarine/src/particle_functions.rs
+++ b/aquamarine/src/particle_functions.rs
@@ -26,7 +26,6 @@ use futures::{FutureExt, StreamExt};
 use humantime::format_duration as pretty;
 use serde_json::json;
 use serde_json::Value as JValue;
-use tokio::runtime::Handle;
 use tracing::{instrument, Instrument, Span};
 
 use particle_args::{Args, JError};
@@ -36,6 +35,7 @@ use particle_execution::{
 use peer_metrics::FunctionKind;
 
 use crate::log::builtin_log_fn;
+use crate::spawner::{SpawnFunctions, Spawner};
 
 #[derive(Clone, Debug)]
 /// Performance statistics about executed function call
@@ -100,7 +100,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
     #[instrument(level = tracing::Level::INFO, skip_all)]
     pub fn execute(
         &mut self,
-        runtime_handle: Handle,
+        spawner: Spawner,
         particle_id: String,
         requests: CallRequests,
         waker: Waker,
@@ -110,7 +110,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
             .into_iter()
             .map(|(id, call)| {
                 self.call(
-                    runtime_handle.clone(),
+                    spawner.clone(),
                     particle_id.clone(),
                     id,
                     call,
@@ -145,7 +145,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
     #[instrument(level = tracing::Level::INFO, skip_all)]
     fn call(
         &self,
-        runtime_handle: Handle,
+        spawner: Spawner,
         particle_id: String,
         call_id: u32,
         call: CallRequestParams,
@@ -194,48 +194,43 @@ impl<F: ParticleFunctionStatic> Functions<F> {
         let builtins = self.builtins.clone();
         let particle_function = self.particle_function.clone();
         let schedule_wait_start = Instant::now();
-        let result = tokio::task::Builder::new()
-            .name(&format!(
-                "Call function {}:{}",
-                args.service_id, args.function_name
-            ))
-            .spawn_blocking_on(
-                move || {
-                    Handle::current().block_on(async move {
-                        // How much time it took to start execution on blocking pool
-                        let schedule_wait_time = schedule_wait_start.elapsed();
-                        let outcome = builtins.call(args, params).await;
-                        // record whether call was handled by builtin or not. needed for stats.
-                        let mut call_kind = FunctionKind::Service;
-                        let outcome = match outcome {
-                            // If particle_function isn't set, just return what we have
-                            outcome if particle_function.is_none() => outcome,
-                            // If builtins weren't defined over these args, try particle_function
-                            FunctionOutcome::NotDefined { args, params } => {
-                                let func = particle_function.unwrap();
-                                // TODO: Actors would allow to get rid of Mutex
-                                //       i.e., wrap each callback with a queue & channel
-                                let func = func.lock().await;
-                                let outcome = func.call(args, params).await;
-                                call_kind = FunctionKind::ParticleFunction;
-                                outcome
-                            }
-                            // Builtins were called, return their outcome
-                            outcome => outcome,
-                        };
-                        // How much time it took to execute the call
-                        // TODO: Time for ParticleFunction includes lock time, which is not good. Low priority cuz ParticleFunctions are barely used.
-                        let call_time = schedule_wait_start.elapsed() - schedule_wait_time;
-                        (outcome, call_kind, call_time, schedule_wait_time)
-                    })
-                },
-                &runtime_handle,
-            )
-            .expect("Could not spawn task");
+
+        let function_identity = format!("{}:{}", &args.service_id, &args.function_name);
+
+        let fut = async move {
+            // How much time it took to start execution on blocking pool
+            let schedule_wait_time = schedule_wait_start.elapsed();
+            let outcome = builtins.call(args, params).await;
+            // record whether call was handled by builtin or not. needed for stats.
+            let mut call_kind = FunctionKind::Service;
+            let outcome = match outcome {
+                // If particle_function isn't set, just return what we have
+                outcome if particle_function.is_none() => outcome,
+                // If builtins weren't defined over these args, try particle_function
+                FunctionOutcome::NotDefined { args, params } => {
+                    let func = particle_function.unwrap();
+                    // TODO: Actors would allow to get rid of Mutex
+                    //       i.e., wrap each callback with a queue & channel
+                    let func = func.lock().await;
+                    let outcome = func.call(args, params).await;
+                    call_kind = FunctionKind::ParticleFunction;
+                    outcome
+                }
+                // Builtins were called, return their outcome
+                outcome => outcome,
+            };
+            // How much time it took to execute the call
+            // TODO: Time for ParticleFunction includes lock time, which is not good. Low priority cuz ParticleFunctions are barely used.
+            let call_time = schedule_wait_start.elapsed() - schedule_wait_time;
+            (outcome, call_kind, call_time, schedule_wait_time)
+        };
+
+        let spawned_future = spawner.spawn_function_call(function_identity, fut);
 
         async move {
-            let (result, call_kind, call_time, wait_time) =
-                result.await.expect("Could not 'Call function' join");
+            let (result, call_kind, call_time, wait_time) = spawned_future
+                .await
+                .expect("Could not 'Call function' join");
 
             let result = match result {
                 FunctionOutcome::NotDefined { args, .. } => Err(JError::new(format!(

--- a/aquamarine/src/particle_functions.rs
+++ b/aquamarine/src/particle_functions.rs
@@ -100,7 +100,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
     #[instrument(level = tracing::Level::INFO, skip_all)]
     pub fn execute(
         &mut self,
-        handle: Handle,
+        runtime_handle: Handle,
         particle_id: String,
         requests: CallRequests,
         waker: Waker,
@@ -110,7 +110,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
             .into_iter()
             .map(|(id, call)| {
                 self.call(
-                    handle.clone(),
+                    runtime_handle.clone(),
                     particle_id.clone(),
                     id,
                     call,
@@ -145,7 +145,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
     #[instrument(level = tracing::Level::INFO, skip_all)]
     fn call(
         &self,
-        handle: Handle,
+        runtime_handle: Handle,
         particle_id: String,
         call_id: u32,
         call: CallRequestParams,
@@ -229,7 +229,7 @@ impl<F: ParticleFunctionStatic> Functions<F> {
                         (outcome, call_kind, call_time, schedule_wait_time)
                     })
                 },
-                &handle,
+                &runtime_handle,
             )
             .expect("Could not spawn task");
 

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -69,6 +69,7 @@ pub struct Plumber<RT: AquaRuntime, F> {
     workers: Arc<Workers>,
     scope: PeerScope,
     cleanup_future: Option<BoxFuture<'static, ()>>,
+    root_runtime_handle: Handle,
 }
 
 impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
@@ -91,6 +92,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
             workers,
             scope,
             cleanup_future: None,
+            root_runtime_handle: Handle::current(),
         }
     }
 
@@ -153,7 +155,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
                     let handle = self
                         .workers
                         .get_handle(worker_id)
-                        .unwrap_or(Handle::current());
+                        .unwrap_or(self.root_runtime_handle.clone());
                     let actor = Actor::new(
                         particle.as_ref(),
                         functions,

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -25,6 +25,7 @@ use std::{
 };
 
 use futures::task::Waker;
+use tokio::runtime::Handle;
 use tokio::task;
 use tracing::instrument;
 
@@ -149,12 +150,17 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
                 let deal_id = self.workers.get_deal_id(worker_id).ok();
                 let data_store = self.data_store.clone();
                 key_pair.map(|kp| {
+                    let handle = self
+                        .workers
+                        .get_handle(worker_id)
+                        .unwrap_or(Handle::current());
                     let actor = Actor::new(
                         particle.as_ref(),
                         functions,
                         worker_id,
                         kp,
                         data_store,
+                        handle,
                         deal_id,
                     );
                     entry.insert(actor)

--- a/aquamarine/src/plumber.rs
+++ b/aquamarine/src/plumber.rs
@@ -39,7 +39,7 @@ use peer_metrics::ParticleExecutorMetrics;
 /// Get current time from OS
 #[cfg(not(test))]
 use real_time::now_ms;
-use workers::{Scope, Workers};
+use workers::{PeerScope, Workers};
 
 use crate::actor::{Actor, ActorPoll};
 use crate::aqua_runtime::AquaRuntime;
@@ -67,7 +67,7 @@ pub struct Plumber<RT: AquaRuntime, F> {
     waker: Option<Waker>,
     metrics: Option<ParticleExecutorMetrics>,
     workers: Arc<Workers>,
-    scope: Scope,
+    scope: PeerScope,
     cleanup_future: Option<BoxFuture<'static, ()>>,
 }
 
@@ -78,7 +78,7 @@ impl<RT: AquaRuntime, F: ParticleFunctionStatic> Plumber<RT, F> {
         builtins: F,
         metrics: Option<ParticleExecutorMetrics>,
         workers: Arc<Workers>,
-        scope: Scope,
+        scope: PeerScope,
     ) -> Self {
         Self {
             vm_pool,
@@ -387,7 +387,7 @@ mod tests {
     use fluence_keypair::KeyPair;
     use fluence_libp2p::RandomPeerId;
     use futures::task::noop_waker_ref;
-    use workers::{KeyStorage, Scope, Workers};
+    use workers::{KeyStorage, PeerScope, Workers};
 
     use particle_args::Args;
     use particle_execution::{FunctionOutcome, ParticleFunction, ParticleParams, ServiceFunction};
@@ -486,7 +486,7 @@ mod tests {
 
         let key_storage = Arc::new(key_storage);
 
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             root_key_pair.get_peer_id(),
             RandomPeerId::random(),
             RandomPeerId::random(),

--- a/aquamarine/src/spawner.rs
+++ b/aquamarine/src/spawner.rs
@@ -19,13 +19,13 @@ pub(crate) trait SpawnFunctions {
 
 #[derive(Clone)]
 #[enum_dispatch(SpawnFunctions)]
-pub(crate) enum Spawner {
+pub enum Spawner {
     Root(RootSpawner),
     Worker(WorkerSpawner),
 }
 
 #[derive(Clone)]
-pub(crate) struct RootSpawner {
+pub struct RootSpawner {
     runtime_handle: Handle,
 }
 
@@ -63,7 +63,7 @@ impl SpawnFunctions for RootSpawner {
 }
 
 #[derive(Clone)]
-pub(crate) struct WorkerSpawner {
+pub struct WorkerSpawner {
     worker_id: PeerId,
     runtime_handle: Handle,
 }

--- a/aquamarine/src/spawner.rs
+++ b/aquamarine/src/spawner.rs
@@ -54,7 +54,7 @@ pub(crate) trait SpawnFunctions {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static;
 
-    /// Spawns a task for asynchronous I/O operations.
+    /// Shift execution to the specific pool
     ///
     /// # Parameters
     ///
@@ -66,8 +66,8 @@ pub(crate) trait SpawnFunctions {
     ///
     /// # Type Parameters
     ///
-    /// - `F`: The type of the future representing the asynchronous I/O task.
-    fn spawn_io<F>(&self, fut: F) -> TokioContext<F>
+    /// - `F`: The type of the future representing the asynchronous task.
+    fn wrap<F>(&self, fut: F) -> TokioContext<F>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;
@@ -130,7 +130,7 @@ impl SpawnFunctions for RootSpawner {
         self.runtime_handle.spawn_blocking(fut)
     }
 
-    fn spawn_io<F>(&self, fut: F) -> TokioContext<F>
+    fn wrap<F>(&self, fut: F) -> TokioContext<F>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
@@ -186,7 +186,7 @@ impl SpawnFunctions for WorkerSpawner {
         self.runtime_handle.spawn(async { fut() })
     }
 
-    fn spawn_io<F>(&self, fut: F) -> TokioContext<F>
+    fn wrap<F>(&self, fut: F) -> TokioContext<F>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,

--- a/aquamarine/src/spawner.rs
+++ b/aquamarine/src/spawner.rs
@@ -39,7 +39,7 @@ pub(crate) trait SpawnFunctions {
     ///
     /// # Parameters
     ///
-    /// - `fut`: The closure returning a result of type `R` when executed asynchronously.
+    /// - `func`: The closure returning a result of type `R` when executed asynchronously.
     ///
     /// # Returns
     ///
@@ -49,7 +49,7 @@ pub(crate) trait SpawnFunctions {
     ///
     /// - `F`: The type of the closure.
     /// - `R`: The type of the result returned by the closure.
-    fn spawn_avm_call<F, R>(&self, fut: F) -> JoinHandle<F::Output>
+    fn spawn_avm_call<F, R>(&self, func: F) -> JoinHandle<F::Output>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static;
@@ -122,12 +122,12 @@ impl SpawnFunctions for RootSpawner {
             .expect("Failed to spawn a task")
     }
 
-    fn spawn_avm_call<F, R>(&self, fut: F) -> JoinHandle<F::Output>
+    fn spawn_avm_call<F, R>(&self, func: F) -> JoinHandle<F::Output>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.runtime_handle.spawn_blocking(fut)
+        self.runtime_handle.spawn_blocking(func)
     }
 
     fn wrap<F>(&self, fut: F) -> TokioContext<F>
@@ -178,12 +178,12 @@ impl SpawnFunctions for WorkerSpawner {
             .expect("Failed to spawn a task")
     }
 
-    fn spawn_avm_call<F, R>(&self, fut: F) -> JoinHandle<F::Output>
+    fn spawn_avm_call<F, R>(&self, func: F) -> JoinHandle<F::Output>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.runtime_handle.spawn(async { fut() })
+        self.runtime_handle.spawn(async { func() })
     }
 
     fn wrap<F>(&self, fut: F) -> TokioContext<F>

--- a/aquamarine/src/spawner.rs
+++ b/aquamarine/src/spawner.rs
@@ -1,0 +1,109 @@
+use enum_dispatch::enum_dispatch;
+use libp2p::PeerId;
+use std::future::Future;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+
+#[enum_dispatch]
+pub trait SpawnFunctions {
+    fn spawn_function_call<F>(&self, function_identity: String, fut: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+    fn spawn_avm_call<F, R>(&self, fut: F) -> JoinHandle<F::Output>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static;
+}
+
+#[derive(Clone)]
+#[enum_dispatch(SpawnFunctions)]
+pub enum Spawner {
+    Root(RootSpawner),
+    Worker(WorkerSpawner),
+}
+
+#[derive(Clone)]
+pub struct RootSpawner {
+    runtime_handle: Handle,
+}
+
+impl RootSpawner {
+    pub fn new(runtime_handle: Handle) -> Self {
+        Self { runtime_handle }
+    }
+}
+impl SpawnFunctions for RootSpawner {
+    fn spawn_function_call<F: Future>(
+        &self,
+        function_identity: String,
+        fut: F,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let task_name = format!("Call function root:{}", &function_identity);
+        let builder = tokio::task::Builder::new().name(task_name.as_str());
+
+        let handle = self.runtime_handle.clone();
+        builder
+            .spawn_blocking_on(move || handle.block_on(fut), &self.runtime_handle)
+            .expect("Failed to spawn a task")
+    }
+
+    fn spawn_avm_call<F, R>(&self, fut: F) -> JoinHandle<F::Output>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.runtime_handle.spawn_blocking(fut)
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkerSpawner {
+    worker_id: PeerId,
+    runtime_handle: Handle,
+}
+
+impl WorkerSpawner {
+    pub fn new(runtime_handle: Handle, worker_id: PeerId) -> Self {
+        Self {
+            runtime_handle,
+            worker_id,
+        }
+    }
+}
+
+impl SpawnFunctions for WorkerSpawner {
+    fn spawn_function_call<F: Future>(
+        &self,
+        function_identity: String,
+        fut: F,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let task_name = format!(
+            "Call function {}:{}",
+            self.worker_id.to_string(),
+            &function_identity
+        );
+
+        let builder = tokio::task::Builder::new().name(task_name.as_str());
+
+        builder
+            .spawn_on(fut, &self.runtime_handle)
+            .expect("Failed to spawn a task")
+    }
+
+    fn spawn_avm_call<F, R>(&self, fut: F) -> JoinHandle<F::Output>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.runtime_handle.spawn(async { fut() })
+    }
+}

--- a/crates/kademlia/src/behaviour.rs
+++ b/crates/kademlia/src/behaviour.rs
@@ -525,7 +525,7 @@ impl NetworkBehaviour for Kademlia {
         let kademlia_span = tracing::info_span!(parent: &self.parent_span, "Kademlia");
         #[cfg(test)]
         let _enter = kademlia_span.enter();
-        log::info!("Behaviour event {:?}", event);
+        log::trace!("Behaviour event {:?}", event);
         match event {
             FromSwarm::ConnectionEstablished(e) => {
                 self.kademlia

--- a/crates/spell-service-api/src/lib.rs
+++ b/crates/spell-service-api/src/lib.rs
@@ -281,7 +281,7 @@ mod tests {
     use maplit::hashmap;
     use serde_json::json;
     use std::time::Duration;
-    use workers::{KeyStorage, Scope, Workers};
+    use workers::{KeyStorage, PeerScope, Workers};
 
     use crate::{CallParams, SpellServiceApi};
 
@@ -311,7 +311,7 @@ mod tests {
 
         let key_storage = Arc::new(key_storage);
 
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             root_key_pair.get_peer_id(),
             management_pid,
             root_key_pair.get_peer_id(),

--- a/crates/workers/src/error.rs
+++ b/crates/workers/src/error.rs
@@ -137,8 +137,9 @@ pub enum WorkersError {
     },
     #[error("Keypair for peer_id {0} not found")]
     KeypairNotFound(PeerId),
-    #[error("Failed to create runtime: {err}")]
+    #[error("Failed to create runtime for worker {worker_id}: {err}")]
     CreateRuntime {
+        worker_id: PeerId,
         #[source]
         err: std::io::Error,
     },

--- a/crates/workers/src/error.rs
+++ b/crates/workers/src/error.rs
@@ -137,4 +137,9 @@ pub enum WorkersError {
     },
     #[error("Keypair for peer_id {0} not found")]
     KeypairNotFound(PeerId),
+    #[error("Failed to create runtime: {err}")]
+    CreateRuntime {
+        #[source]
+        err: std::io::Error,
+    },
 }

--- a/crates/workers/src/lib.rs
+++ b/crates/workers/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::KeyStorageError;
 pub use error::WorkersError;
 use fluence_libp2p::PeerId;
 pub use key_storage::KeyStorage;
-pub use scope::Scope;
+pub use scope::PeerScope;
 pub use workers::CreateWorkerParams;
 pub use workers::Workers;
 

--- a/crates/workers/src/lib.rs
+++ b/crates/workers/src/lib.rs
@@ -15,6 +15,7 @@ pub use error::WorkersError;
 use fluence_libp2p::PeerId;
 pub use key_storage::KeyStorage;
 pub use scope::Scope;
+pub use workers::CreateWorkerParams;
 pub use workers::Workers;
 
 const DEFAULT_PARALLELISM: usize = 2;

--- a/crates/workers/src/lib.rs
+++ b/crates/workers/src/lib.rs
@@ -15,7 +15,7 @@ pub use error::WorkersError;
 use fluence_libp2p::PeerId;
 pub use key_storage::KeyStorage;
 pub use scope::PeerScope;
-pub use workers::CreateWorkerParams;
+pub use workers::WorkerParams;
 pub use workers::Workers;
 
 const DEFAULT_PARALLELISM: usize = 2;

--- a/crates/workers/src/persistence.rs
+++ b/crates/workers/src/persistence.rs
@@ -57,6 +57,7 @@ pub struct PersistedWorker {
     pub deal_id: String,
     #[serde(default = "default_bool::<true>")]
     pub active: bool,
+    pub cu_count: usize,
 }
 
 impl From<PersistedWorker> for WorkerInfo {
@@ -65,6 +66,7 @@ impl From<PersistedWorker> for WorkerInfo {
             deal_id: val.deal_id,
             creator: val.creator,
             active: RwLock::new(val.active),
+            cu_count: val.cu_count,
         }
     }
 }

--- a/crates/workers/src/scope.rs
+++ b/crates/workers/src/scope.rs
@@ -6,14 +6,14 @@ use std::sync::Arc;
 /// Represents information about various peer IDs.
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct Scope {
+pub struct PeerScope {
     host_peer_id: PeerId,
     management_peer_id: PeerId,
     builtins_management_peer_id: PeerId,
     #[derivative(Debug = "ignore")]
     key_storage: Arc<KeyStorage>,
 }
-impl Scope {
+impl PeerScope {
     pub fn new(
         host_peer_id: PeerId,
         management_peer_id: PeerId,

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -145,9 +145,6 @@ impl Workers {
                 match worker_info {
                     Ok(worker_info) => {
                         let mut worker_ids = self.worker_ids.write();
-                        let mut worker_infos = self.worker_infos.write();
-                        let mut runtimes = self.runtimes.write();
-
                         if worker_ids.contains_key(&deal_id) {
                             return Err(WorkersError::WorkerAlreadyExists { deal_id });
                         }
@@ -157,6 +154,9 @@ impl Workers {
                             .max_blocking_threads(params.cu_count)
                             .build()
                             .map_err(|err| WorkersError::CreateRuntime { worker_id, err })?;
+
+                        let mut worker_infos = self.worker_infos.write();
+                        let mut runtimes = self.runtimes.write();
 
                         worker_ids.insert(deal_id, worker_id);
                         worker_infos.insert(worker_id, worker_info);

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -86,18 +86,12 @@ impl Workers {
             worker_infos.insert(worker_id, w.into());
             worker_ids.insert(deal_id, worker_id);
 
-            let runtime = tokio::task::spawn_blocking(move || {
-                let runtime = tokio::runtime::Builder::new_multi_thread()
-                    .thread_name(format!("worker-pool-{}", worker_id))
-                    .worker_threads(cu_count)
-                    .max_blocking_threads(cu_count)
-                    .build()
-                    .map_err(|err| WorkersError::CreateRuntime { worker_id, err })
-                    .unwrap();
-                runtime
-            })
-            .await
-            .unwrap();
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .thread_name(format!("worker-pool-{}", worker_id))
+                .worker_threads(cu_count)
+                .max_blocking_threads(cu_count)
+                .build()
+                .map_err(|err| WorkersError::CreateRuntime { worker_id, err })?;
 
             runtimes.insert(worker_id, runtime);
         }

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -100,7 +100,7 @@ impl Workers {
         })
     }
 
-    fn build_runtime(worker_id: PeerId, cu_count: usize) -> eyre::Result<Runtime> {
+    fn build_runtime(worker_id: PeerId, cu_count: usize) -> Result<Runtime, WorkersError> {
         // Creating a multi-threaded Tokio runtime with a total of cu_count * 2 threads.
         // We assume cu_count threads per logical processor, aligning with the common practice.
         let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -18,7 +18,7 @@ pub struct WorkerInfo {
     pub creator: PeerId,
     /// A read-write lock indicating whether the worker is active.
     pub active: RwLock<bool>,
-
+    /// A count of compute units available for this worker.
     pub cu_count: usize,
 }
 
@@ -38,13 +38,13 @@ pub struct Workers {
     runtimes: RwLock<HashMap<WorkerId, Runtime>>,
 }
 
-pub struct CreateWorkerParams {
+pub struct WorkerParams {
     deal_id: String,
     init_peer_id: PeerId,
     cu_count: usize,
 }
 
-impl CreateWorkerParams {
+impl WorkerParams {
     pub fn new(deal_id: String, init_peer_id: PeerId, cu_count: usize) -> Self {
         Self {
             deal_id,
@@ -127,7 +127,7 @@ impl Workers {
     /// - `Ok(worker_id)` if the worker is successfully created, returning the ID of the created worker.
     /// - `Err(WorkersError)` if an error occurs, such as the worker already existing or key pair creation failure.
     ///
-    pub async fn create_worker(&self, params: CreateWorkerParams) -> Result<PeerId, WorkersError> {
+    pub async fn create_worker(&self, params: WorkerParams) -> Result<PeerId, WorkersError> {
         let deal_id = params.deal_id;
         let init_peer_id = params.init_peer_id;
         let cu_count = params.cu_count;
@@ -491,7 +491,7 @@ impl Workers {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CreateWorkerParams, KeyStorage, PeerScope, Workers};
+    use crate::{KeyStorage, PeerScope, WorkerParams, Workers};
     use libp2p::PeerId;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -557,7 +557,7 @@ mod tests {
 
         let creator_peer_id = PeerId::random();
         let worker_id = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_1".to_string(),
                 creator_peer_id,
                 1,
@@ -627,7 +627,7 @@ mod tests {
             .expect("Failed to create Workers from path");
 
         let worker_id = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_1".to_string(),
                 PeerId::random(),
                 1,
@@ -641,7 +641,7 @@ mod tests {
         assert_eq!(deal_id, "deal_id_1".to_string());
 
         let res = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_1".to_string(),
                 PeerId::random(),
                 1,
@@ -684,7 +684,7 @@ mod tests {
             .expect("Failed to create Workers from path");
 
         let worker_id_1 = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_1".to_string(),
                 PeerId::random(),
                 1,
@@ -693,7 +693,7 @@ mod tests {
             .expect("Failed to create worker");
 
         let worker_id_2 = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_2".to_string(),
                 PeerId::random(),
                 1,
@@ -752,7 +752,7 @@ mod tests {
             .expect("Failed to create Workers from path");
 
         let worker_id_1 = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_1".to_string(),
                 PeerId::random(),
                 1,
@@ -761,7 +761,7 @@ mod tests {
             .expect("Failed to create worker");
 
         let worker_id_2 = workers
-            .create_worker(CreateWorkerParams::new(
+            .create_worker(WorkerParams::new(
                 "deal_id_2".to_string(),
                 PeerId::random(),
                 1,

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -86,9 +86,13 @@ impl Workers {
             worker_infos.insert(worker_id, w.into());
             worker_ids.insert(deal_id, worker_id);
 
+            // Creating a multi-threaded Tokio runtime with a total of cu_count * 2 threads.
+            // We assume cu_count threads per logical processor, aligning with the common practice.
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .thread_name(format!("worker-pool-{}", worker_id))
+                // Configuring worker threads for executing service calls and particles
                 .worker_threads(cu_count)
+                // Configuring blocking threads for handling I/O
                 .max_blocking_threads(cu_count)
                 .build()
                 .map_err(|err| WorkersError::CreateRuntime { worker_id, err })?;

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -8,6 +8,7 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::runtime::{Handle, Runtime};
 
 /// Information about a worker.
 pub struct WorkerInfo {
@@ -17,6 +18,8 @@ pub struct WorkerInfo {
     pub creator: PeerId,
     /// A read-write lock indicating whether the worker is active.
     pub active: RwLock<bool>,
+
+    pub cu_count: usize,
 }
 
 /// Manages a collection of workers.
@@ -31,6 +34,24 @@ pub struct Workers {
     key_storage: Arc<KeyStorage>,
     /// Scope information used to determine the host and manage key pairs.
     scope: Scope,
+    /// Mapping of worker IDs to worker runtime.
+    runtimes: RwLock<HashMap<WorkerId, Runtime>>,
+}
+
+pub struct CreateWorkerParams {
+    deal_id: String,
+    init_peer_id: PeerId,
+    cu_count: usize,
+}
+
+impl CreateWorkerParams {
+    pub fn new(deal_id: String, init_peer_id: PeerId, cu_count: usize) -> Self {
+        Self {
+            deal_id,
+            init_peer_id,
+            cu_count,
+        }
+    }
 }
 
 impl Workers {
@@ -56,12 +77,29 @@ impl Workers {
         let workers = load_persisted_workers(workers_dir.as_path()).await?;
         let mut worker_ids = HashMap::with_capacity(workers.len());
         let mut worker_infos = HashMap::with_capacity(workers.len());
+        let mut runtimes = HashMap::with_capacity(workers.len());
 
         for w in workers {
             let worker_id = w.worker_id;
             let deal_id = w.deal_id.clone();
+            let cu_count = w.cu_count;
             worker_infos.insert(worker_id, w.into());
             worker_ids.insert(deal_id, worker_id);
+
+            let runtime = tokio::task::spawn_blocking(move || {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .thread_name(format!("worker-pool-{}", worker_id))
+                    .worker_threads(cu_count)
+                    .max_blocking_threads(cu_count)
+                    .build()
+                    .map_err(|err| WorkersError::CreateRuntime { err })
+                    .unwrap();
+                runtime
+            })
+            .await
+            .unwrap();
+
+            runtimes.insert(worker_id, runtime);
         }
         Ok(Self {
             worker_ids: RwLock::new(worker_ids),
@@ -69,6 +107,7 @@ impl Workers {
             workers_dir,
             key_storage,
             scope,
+            runtimes: RwLock::new(runtimes),
         })
     }
 
@@ -85,11 +124,11 @@ impl Workers {
     /// - `Ok(worker_id)` if the worker is successfully created, returning the ID of the created worker.
     /// - `Err(WorkersError)` if an error occurs, such as the worker already existing or key pair creation failure.
     ///
-    pub async fn create_worker(
-        &self,
-        deal_id: String,
-        init_peer_id: PeerId,
-    ) -> Result<PeerId, WorkersError> {
+    pub async fn create_worker(&self, params: CreateWorkerParams) -> Result<PeerId, WorkersError> {
+        let deal_id = params.deal_id;
+        let init_peer_id = params.init_peer_id;
+        let cu_count = params.cu_count;
+
         let worker_id = {
             let guard = self.worker_ids.read();
             guard.get(&deal_id).cloned()
@@ -106,20 +145,28 @@ impl Workers {
                 let worker_id = key_pair.get_peer_id();
 
                 let worker_info = self
-                    .store_worker(worker_id, deal_id.clone(), init_peer_id)
+                    .store_worker(worker_id, deal_id.clone(), init_peer_id, cu_count)
                     .await;
 
                 match worker_info {
                     Ok(worker_info) => {
                         let mut worker_ids = self.worker_ids.write();
                         let mut worker_infos = self.worker_infos.write();
+                        let mut runtimes = self.runtimes.write();
 
                         if worker_ids.contains_key(&deal_id) {
                             return Err(WorkersError::WorkerAlreadyExists { deal_id });
                         }
 
+                        let runtime = tokio::runtime::Builder::new_multi_thread()
+                            .worker_threads(params.cu_count)
+                            .max_blocking_threads(params.cu_count)
+                            .build()
+                            .map_err(|err| WorkersError::CreateRuntime { err })?;
+
                         worker_ids.insert(deal_id, worker_id);
                         worker_infos.insert(worker_id, worker_info);
+                        runtimes.insert(worker_id, runtime);
                     }
                     Err(err) => {
                         tracing::warn!(
@@ -216,11 +263,18 @@ impl Workers {
 
         let mut worker_ids = self.worker_ids.write();
         let mut worker_infos = self.worker_infos.write();
+        let mut runtimes = self.runtimes.write();
         let removed_worker_id = worker_ids.remove(&deal_id);
         let removed_worker_info = worker_infos.remove(&worker_id);
+        let removed_runtime = runtimes.remove(&worker_id);
 
         debug_assert!(removed_worker_id.is_some(), "worker_id does not exist");
         debug_assert!(removed_worker_info.is_some(), "worker info does not exist");
+        debug_assert!(removed_runtime.is_some(), "worker info does not exist");
+
+        if let Some(runtime) = removed_runtime {
+            runtime.shutdown_background();
+        }
 
         Ok(())
     }
@@ -272,6 +326,14 @@ impl Workers {
         }
     }
 
+    pub fn get_handle(&self, worker_id: PeerId) -> Result<Handle, WorkersError> {
+        self.runtimes
+            .read()
+            .get(&worker_id)
+            .map(|x| x.handle().clone())
+            .ok_or(WorkersError::WorkerNotFound(worker_id))
+    }
+
     /// Persists worker information and updates internal data structures.
     ///
     /// This method stores information about the worker identified by `worker_id` and associates
@@ -296,6 +358,7 @@ impl Workers {
         worker_id: PeerId,
         deal_id: String,
         creator: PeerId,
+        cu_count: usize,
     ) -> Result<WorkerInfo, WorkersError> {
         persist_worker(
             &self.workers_dir,
@@ -305,6 +368,7 @@ impl Workers {
                 creator,
                 deal_id: deal_id.clone(),
                 active: true,
+                cu_count,
             },
         )
         .await?;
@@ -312,12 +376,13 @@ impl Workers {
             deal_id,
             creator,
             active: RwLock::new(true),
+            cu_count,
         };
         Ok(worker_info)
     }
 
     async fn set_worker_status(&self, worker_id: PeerId, status: bool) -> Result<(), WorkersError> {
-        let (creator, deal_id) = {
+        let (creator, deal_id, cu_count) = {
             let guard = self.worker_infos.read();
             let worker_info = guard
                 .get(&worker_id)
@@ -325,7 +390,11 @@ impl Workers {
             let mut active = worker_info.active.write();
             *active = status;
 
-            (worker_info.creator, worker_info.deal_id.clone())
+            (
+                worker_info.creator,
+                worker_info.deal_id.clone(),
+                worker_info.cu_count,
+            )
         };
 
         persist_worker(
@@ -336,6 +405,7 @@ impl Workers {
                 creator,
                 deal_id,
                 active: status,
+                cu_count,
             },
         )
         .await?;
@@ -422,7 +492,7 @@ impl Workers {
 
 #[cfg(test)]
 mod tests {
-    use crate::{KeyStorage, Scope, Workers};
+    use crate::{CreateWorkerParams, KeyStorage, Scope, Workers};
     use libp2p::PeerId;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -488,7 +558,11 @@ mod tests {
 
         let creator_peer_id = PeerId::random();
         let worker_id = workers
-            .create_worker("deal_id_1".to_string(), creator_peer_id)
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_1".to_string(),
+                creator_peer_id,
+                1,
+            ))
             .await
             .expect("Failed to create worker");
 
@@ -523,6 +597,8 @@ mod tests {
             .get_worker_id("deal_id_1".to_string())
             .expect("Failed to get worker id");
         assert_eq!(worker_id_1, worker_id);
+        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 
     #[tokio::test]
@@ -552,7 +628,11 @@ mod tests {
             .expect("Failed to create Workers from path");
 
         let worker_id = workers
-            .create_worker("deal_id_1".to_string(), PeerId::random())
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_1".to_string(),
+                PeerId::random(),
+                1,
+            ))
             .await
             .expect("Failed to create worker");
 
@@ -562,14 +642,20 @@ mod tests {
         assert_eq!(deal_id, "deal_id_1".to_string());
 
         let res = workers
-            .create_worker("deal_id_1".to_string(), PeerId::random())
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_1".to_string(),
+                PeerId::random(),
+                1,
+            ))
             .await;
 
         assert!(res.is_err());
         assert_eq!(
             res.err().unwrap().to_string(),
             "Worker for deal_id_1 already exists"
-        )
+        );
+        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 
     #[tokio::test]
@@ -599,12 +685,20 @@ mod tests {
             .expect("Failed to create Workers from path");
 
         let worker_id_1 = workers
-            .create_worker("deal_id_1".to_string(), PeerId::random())
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_1".to_string(),
+                PeerId::random(),
+                1,
+            ))
             .await
             .expect("Failed to create worker");
 
         let worker_id_2 = workers
-            .create_worker("deal_id_2".to_string(), PeerId::random())
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_2".to_string(),
+                PeerId::random(),
+                1,
+            ))
             .await
             .expect("Failed to create worker");
 
@@ -628,6 +722,8 @@ mod tests {
         let key_2 = key_storage.get_key_pair(worker_id_2);
         assert!(key_1.is_some());
         assert!(key_2.is_none());
+        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 
     #[tokio::test]
@@ -657,12 +753,20 @@ mod tests {
             .expect("Failed to create Workers from path");
 
         let worker_id_1 = workers
-            .create_worker("deal_id_1".to_string(), PeerId::random())
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_1".to_string(),
+                PeerId::random(),
+                1,
+            ))
             .await
             .expect("Failed to create worker");
 
         let worker_id_2 = workers
-            .create_worker("deal_id_2".to_string(), PeerId::random())
+            .create_worker(CreateWorkerParams::new(
+                "deal_id_2".to_string(),
+                PeerId::random(),
+                1,
+            ))
             .await
             .expect("Failed to create worker");
 
@@ -696,7 +800,8 @@ mod tests {
         assert!(!status);
         drop(key_storage);
         drop(scope);
-        drop(workers);
+        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
 
         // Create a new KeyStorage instance
         let key_storage = Arc::new(
@@ -726,5 +831,7 @@ mod tests {
         assert!(key_2.is_none());
         let status = workers.is_worker_active(worker_id_1);
         assert!(!status);
+        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 }

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -591,7 +591,7 @@ mod tests {
             .get_worker_id("deal_id_1".to_string())
             .expect("Failed to get worker id");
         assert_eq!(worker_id_1, worker_id);
-        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        // tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
         tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 
@@ -648,7 +648,7 @@ mod tests {
             res.err().unwrap().to_string(),
             "Worker for deal_id_1 already exists"
         );
-        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        // tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
         tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 
@@ -716,7 +716,7 @@ mod tests {
         let key_2 = key_storage.get_key_pair(worker_id_2);
         assert!(key_1.is_some());
         assert!(key_2.is_none());
-        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        // tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
         tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 
@@ -794,7 +794,7 @@ mod tests {
         assert!(!status);
         drop(key_storage);
         drop(scope);
-        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        // tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
         tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
 
         // Create a new KeyStorage instance
@@ -825,7 +825,7 @@ mod tests {
         assert!(key_2.is_none());
         let status = workers.is_worker_active(worker_id_1);
         assert!(!status);
-        //tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
+        // tokio doesn't allow to drop runtimes in async context, so shifting workers drop to the blocking thread
         tokio::task::spawn_blocking(|| drop(workers)).await.unwrap();
     }
 }

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -1,6 +1,6 @@
 use crate::error::WorkersError;
 use crate::persistence::{load_persisted_workers, persist_worker, remove_worker, PersistedWorker};
-use crate::scope::Scope;
+use crate::scope::PeerScope;
 use crate::{DealId, KeyStorage, WorkerId};
 use fluence_keypair::KeyPair;
 use fluence_libp2p::PeerId;
@@ -33,7 +33,7 @@ pub struct Workers {
     /// Key storage for managing worker key pairs.
     key_storage: Arc<KeyStorage>,
     /// Scope information used to determine the host and manage key pairs.
-    scope: Scope,
+    scope: PeerScope,
     /// Mapping of worker IDs to worker runtime.
     runtimes: RwLock<HashMap<WorkerId, Runtime>>,
 }
@@ -72,7 +72,7 @@ impl Workers {
     pub async fn from_path(
         workers_dir: PathBuf,
         key_storage: Arc<KeyStorage>,
-        scope: Scope,
+        scope: PeerScope,
     ) -> eyre::Result<Self> {
         let workers = load_persisted_workers(workers_dir.as_path()).await?;
         let mut worker_ids = HashMap::with_capacity(workers.len());
@@ -492,7 +492,7 @@ impl Workers {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CreateWorkerParams, KeyStorage, Scope, Workers};
+    use crate::{CreateWorkerParams, KeyStorage, PeerScope, Workers};
     use libp2p::PeerId;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -511,7 +511,7 @@ mod tests {
                 .await
                 .expect("Failed to create KeyStorage from path"),
         );
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             PeerId::random(),
             PeerId::random(),
             PeerId::random(),
@@ -544,7 +544,7 @@ mod tests {
                 .expect("Failed to create KeyStorage from path"),
         );
         let host_peer_id = PeerId::random();
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             host_peer_id,
             PeerId::random(),
             PeerId::random(),
@@ -615,7 +615,7 @@ mod tests {
                 .await
                 .expect("Failed to create KeyStorage from path"),
         );
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             PeerId::random(),
             PeerId::random(),
             PeerId::random(),
@@ -672,7 +672,7 @@ mod tests {
                 .await
                 .expect("Failed to create KeyStorage from path"),
         );
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             PeerId::random(),
             PeerId::random(),
             PeerId::random(),
@@ -740,7 +740,7 @@ mod tests {
                 .await
                 .expect("Failed to create KeyStorage from path"),
         );
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             PeerId::random(),
             PeerId::random(),
             PeerId::random(),
@@ -809,7 +809,7 @@ mod tests {
                 .await
                 .expect("Failed to create KeyStorage from path"),
         );
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             PeerId::random(),
             PeerId::random(),
             PeerId::random(),

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -92,7 +92,7 @@ impl Workers {
                     .worker_threads(cu_count)
                     .max_blocking_threads(cu_count)
                     .build()
-                    .map_err(|err| WorkersError::CreateRuntime { err })
+                    .map_err(|err| WorkersError::CreateRuntime { worker_id, err })
                     .unwrap();
                 runtime
             })
@@ -162,7 +162,7 @@ impl Workers {
                             .worker_threads(params.cu_count)
                             .max_blocking_threads(params.cu_count)
                             .build()
-                            .map_err(|err| WorkersError::CreateRuntime { err })?;
+                            .map_err(|err| WorkersError::CreateRuntime { worker_id, err })?;
 
                         worker_ids.insert(deal_id, worker_id);
                         worker_infos.insert(worker_id, worker_info);

--- a/nox/src/node.rs
+++ b/nox/src/node.rs
@@ -56,7 +56,7 @@ use sorcerer::Sorcerer;
 use spell_event_bus::api::{PeerEvent, SpellEventBusApi, TriggerEvent};
 use spell_event_bus::bus::SpellEventBus;
 use system_services::{Deployer, SystemServiceDistros};
-use workers::{KeyStorage, Scope, Workers};
+use workers::{KeyStorage, PeerScope, Workers};
 
 use super::behaviour::FluenceNetworkBehaviour;
 use crate::behaviour::FluenceNetworkBehaviourEvent;
@@ -93,7 +93,7 @@ pub struct Node<RT: AquaRuntime> {
 
     pub builtins_management_peer_id: PeerId,
 
-    pub scope: Scope,
+    pub scope: PeerScope,
 
     allow_local_addresses: bool,
     versions: Versions,
@@ -127,7 +127,7 @@ impl<RT: AquaRuntime> Node<RT> {
 
         let key_storage = Arc::new(key_storage);
 
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             root_key_pair.get_peer_id(),
             config.management_peer_id,
             builtins_peer_id,
@@ -428,7 +428,7 @@ impl<RT: AquaRuntime> Node<RT> {
         services_config: ServicesConfig,
         services_metrics: ServicesMetrics,
         workers: Arc<Workers>,
-        scope: Scope,
+        scope: PeerScope,
         health_registry: Option<&mut HealthCheckRegistry>,
         connector_api_endpoint: String,
     ) -> Builtins<Connectivity> {
@@ -470,7 +470,7 @@ impl<RT: AquaRuntime> Node<RT> {
         services_metrics_backend: ServicesMetricsBackend,
         http_listen_addr: Option<SocketAddr>,
         builtins_management_peer_id: PeerId,
-        scope: Scope,
+        scope: PeerScope,
         allow_local_addresses: bool,
         versions: Versions,
         chain_listener: Option<ChainListener>,

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -46,7 +46,7 @@ use particle_services::{ParticleAppServices, ServiceType};
 use peer_metrics::ServicesMetrics;
 use server_config::ServicesConfig;
 use uuid_utils::uuid;
-use workers::{Scope, Workers};
+use workers::{PeerScope, Workers};
 
 use crate::debug::fmt_custom_services;
 use crate::error::HostClosureCallError;
@@ -89,7 +89,7 @@ pub struct Builtins<C> {
     #[derivative(Debug = "ignore")]
     workers: Arc<Workers>,
     #[derivative(Debug = "ignore")]
-    scope: Scope,
+    scope: PeerScope,
     connector_api_endpoint: String,
 }
 
@@ -102,7 +102,7 @@ where
         config: ServicesConfig,
         services_metrics: ServicesMetrics,
         workers: Arc<Workers>,
-        scope: Scope,
+        scope: PeerScope,
         health_registry: Option<&mut HealthCheckRegistry>,
         connector_api_endpoint: String,
     ) -> Self {

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -40,7 +40,7 @@ use peer_metrics::{
 };
 use server_config::ServicesConfig;
 use uuid_utils::uuid;
-use workers::{Scope, Workers};
+use workers::{PeerScope, Workers};
 
 use crate::error::ServiceError;
 use crate::error::ServiceError::{AliasAsServiceId, Forbidden, NoSuchAlias};
@@ -177,7 +177,7 @@ pub struct ParticleAppServices {
     #[derivative(Debug = "ignore")]
     workers: Arc<Workers>,
     #[derivative(Debug = "ignore")]
-    scope: Scope,
+    scope: PeerScope,
     pub metrics: Option<ServicesMetrics>,
     health: Option<PersistedServiceHealth>,
 }
@@ -262,7 +262,7 @@ impl ParticleAppServices {
         metrics: Option<ServicesMetrics>,
         health_registry: Option<&mut HealthCheckRegistry>,
         workers: Arc<Workers>,
-        scope: Scope,
+        scope: PeerScope,
     ) -> Self {
         let vault = ParticleVault::new(config.particles_vault_dir.clone());
 
@@ -1045,7 +1045,7 @@ mod tests {
     use server_config::ServicesConfig;
     use service_modules::load_module;
     use service_modules::Hash;
-    use workers::{KeyStorage, Scope, Workers};
+    use workers::{KeyStorage, PeerScope, Workers};
 
     use crate::app_services::ServiceType;
     use crate::persistence::load_persisted_services;
@@ -1074,7 +1074,7 @@ mod tests {
 
         let root_key_pair: KeyPair = root_keypair.clone().into();
 
-        let scope = Scope::new(
+        let scope = PeerScope::new(
             root_key_pair.get_peer_id(),
             management_pid,
             root_key_pair.get_peer_id(),

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -44,7 +44,7 @@ use spell_event_bus::api::{from_user_config, SpellEventBusApi, TriggerEvent};
 use spell_service_api::{CallParams, SpellServiceApi};
 use spell_storage::SpellStorage;
 use tracing::Instrument;
-use workers::{Scope, Workers};
+use workers::{PeerScope, Workers};
 
 #[derive(Clone)]
 pub struct Sorcerer {
@@ -54,7 +54,7 @@ pub struct Sorcerer {
     pub spell_event_bus_api: SpellEventBusApi,
     pub spell_script_particle_ttl: Duration,
     pub workers: Arc<Workers>,
-    pub scope: Scope,
+    pub scope: PeerScope,
     pub spell_service_api: SpellServiceApi,
     pub spell_metrics: Option<SpellMetrics>,
     pub worker_period_sec: u32,
@@ -69,7 +69,7 @@ impl Sorcerer {
         config: ResolvedConfig,
         spell_event_bus_api: SpellEventBusApi,
         workers: Arc<Workers>,
-        scope: Scope,
+        scope: PeerScope,
         spell_service_api: SpellServiceApi,
         spell_metrics: Option<SpellMetrics>,
     ) -> (Self, HashMap<String, CustomService>, String) {

--- a/sorcerer/src/spell_builtins.rs
+++ b/sorcerer/src/spell_builtins.rs
@@ -27,7 +27,7 @@ use spell_event_bus::{api, api::SpellEventBusApi};
 use spell_service_api::{CallParams, SpellServiceApi};
 use spell_storage::SpellStorage;
 use std::time::Duration;
-use workers::{Scope, Workers};
+use workers::{PeerScope, Workers};
 
 pub async fn remove_spell(
     particle_id: &str,
@@ -142,7 +142,7 @@ pub(crate) async fn spell_install(
     spell_event_bus_api: SpellEventBusApi,
     spell_service_api: SpellServiceApi,
     workers: Arc<Workers>,
-    scope: Scope,
+    scope: PeerScope,
 ) -> Result<JValue, JError> {
     let mut args = sargs.function_args.clone().into_iter();
     let script: String = Args::next("script", &mut args)?;
@@ -223,7 +223,7 @@ pub(crate) async fn spell_remove(
     services: ParticleAppServices,
     spell_event_bus_api: SpellEventBusApi,
     workers: Arc<Workers>,
-    scope: Scope,
+    scope: PeerScope,
 ) -> Result<(), JError> {
     let mut args = args.function_args.into_iter();
     let spell_id: String = Args::next("spell_id", &mut args)?;
@@ -262,7 +262,7 @@ pub(crate) async fn spell_update_config(
     spell_event_bus_api: SpellEventBusApi,
     spell_service_api: SpellServiceApi,
     workers: Arc<Workers>,
-    scope: Scope,
+    scope: PeerScope,
 ) -> Result<(), JError> {
     let mut args = args.function_args.into_iter();
     let spell_id_or_alias: String = Args::next("spell_id", &mut args)?;

--- a/sorcerer/src/worker_builins.rs
+++ b/sorcerer/src/worker_builins.rs
@@ -28,7 +28,7 @@ use particle_services::ParticleAppServices;
 use spell_event_bus::api::{from_user_config, SpellEventBusApi};
 use spell_service_api::{CallParams, SpellServiceApi};
 use spell_storage::SpellStorage;
-use workers::{Scope, Workers};
+use workers::{CreateWorkerParams, Scope, Workers};
 
 pub(crate) async fn create_worker(
     args: Args,
@@ -37,9 +37,14 @@ pub(crate) async fn create_worker(
 ) -> Result<JValue, JError> {
     let mut args = args.function_args.into_iter();
     let deal_id: String = Args::next("deal_id", &mut args)?;
+    let cu_count: usize = Args::next_opt("cu_count", &mut args)?.unwrap_or(1);
     Ok(JValue::String(
         workers
-            .create_worker(deal_id, params.init_peer_id)
+            .create_worker(CreateWorkerParams::new(
+                deal_id,
+                params.init_peer_id,
+                cu_count,
+            ))
             .await?
             .to_base58(),
     ))

--- a/sorcerer/src/worker_builins.rs
+++ b/sorcerer/src/worker_builins.rs
@@ -28,7 +28,7 @@ use particle_services::ParticleAppServices;
 use spell_event_bus::api::{from_user_config, SpellEventBusApi};
 use spell_service_api::{CallParams, SpellServiceApi};
 use spell_storage::SpellStorage;
-use workers::{CreateWorkerParams, Scope, Workers};
+use workers::{CreateWorkerParams, PeerScope, Workers};
 
 pub(crate) async fn create_worker(
     args: Args,
@@ -118,7 +118,7 @@ pub(crate) async fn deactivate_deal(
     args: Args,
     params: ParticleParams,
     workers: Arc<Workers>,
-    scope: Scope,
+    scope: PeerScope,
     spell_storage: SpellStorage,
     spell_event_bus_api: SpellEventBusApi,
     spell_service_api: SpellServiceApi,
@@ -175,7 +175,7 @@ pub(crate) async fn activate_deal(
     args: Args,
     params: ParticleParams,
     workers: Arc<Workers>,
-    scope: Scope,
+    scope: PeerScope,
     services: ParticleAppServices,
     spell_event_bus_api: SpellEventBusApi,
     spell_service_api: SpellServiceApi,

--- a/sorcerer/src/worker_builins.rs
+++ b/sorcerer/src/worker_builins.rs
@@ -28,7 +28,7 @@ use particle_services::ParticleAppServices;
 use spell_event_bus::api::{from_user_config, SpellEventBusApi};
 use spell_service_api::{CallParams, SpellServiceApi};
 use spell_storage::SpellStorage;
-use workers::{CreateWorkerParams, PeerScope, Workers};
+use workers::{PeerScope, WorkerParams, Workers};
 
 pub(crate) async fn create_worker(
     args: Args,
@@ -40,11 +40,7 @@ pub(crate) async fn create_worker(
     let cu_count: usize = Args::next_opt("cu_count", &mut args)?.unwrap_or(1);
     Ok(JValue::String(
         workers
-            .create_worker(CreateWorkerParams::new(
-                deal_id,
-                params.init_peer_id,
-                cu_count,
-            ))
+            .create_worker(WorkerParams::new(deal_id, params.init_peer_id, cu_count))
             .await?
             .to_base58(),
     ))


### PR DESCRIPTION
## Description
Create a ThreadPool for each worker.

## Motivation
We needed to isolate each worker on a separate CU

## Related Issue(s)
[NET-688](https://linear.app/fluence/issue/NET-688/create-a-threadpool-for-each-worker)

## Proposed Changes
- Added a runtime creation on worker creation 
- On the actor creation get a worker runtime handle if it exists 
- Introduced a Spawner entity that allows to shift executions on the different pools 

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

