### PR TITLE
fix(workers): add io+timer drivers to tokio runtimes [fixes NET-795]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,7 @@ jobs:
   cli:
     needs:
       - nox-snapshot
-    uses: fluencelabs/cli/.github/workflows/tests.yml@renovate/fluencelabs-js-client-0.x
+    uses: fluencelabs/cli/.github/workflows/tests.yml@main
     with:
       ref: renovate/fluencelabs-js-client-0.x
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
@@ -90,7 +90,7 @@ jobs:
   js-client:
     needs:
       - nox-snapshot
-    uses: fluencelabs/js-client/.github/workflows/tests.yml@master
+    uses: fluencelabs/js-client/.github/workflows/tests.yml@main
     with:
       ref: js-client-v0.9.0
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
@@ -98,7 +98,7 @@ jobs:
   aqua:
     needs:
       - nox-snapshot
-    uses: fluencelabs/aqua/.github/workflows/tests.yml@renovate/fluencelabs-js-client-0.x
+    uses: fluencelabs/aqua/.github/workflows/tests.yml@main
     with:
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
       ref: renovate/fluencelabs-js-client-0.x

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,6 @@ jobs:
       - nox-snapshot
     uses: fluencelabs/cli/.github/workflows/tests.yml@main
     with:
-      ref: renovate/fluencelabs-js-client-0.x
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
 
   js-client:
@@ -101,7 +100,6 @@ jobs:
     uses: fluencelabs/aqua/.github/workflows/tests.yml@main
     with:
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
-      ref: renovate/fluencelabs-js-client-0.x
 
   # registry:
   #   needs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,7 @@ jobs:
   aqua:
     needs:
       - nox-snapshot
-    uses: fluencelabs/aqua/.github/workflows/tests.yml@main
+    uses: fluencelabs/aqua/.github/workflows/tests.yml@renovate/fluencelabs-js-client-0.x
     with:
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,14 +91,16 @@ jobs:
       - nox-snapshot
     uses: fluencelabs/js-client/.github/workflows/tests.yml@main
     with:
+      ref: js-client-v0.9.0
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
 
   aqua:
     needs:
       - nox-snapshot
-    uses: fluencelabs/aqua/.github/workflows/tests.yml@renovate/fluencelabs-js-client-0.x
+    uses: fluencelabs/aqua/.github/workflows/tests.yml@main
     with:
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
+      ref: renovate/fluencelabs-js-client-0.x
 
   # registry:
   #   needs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,7 +91,6 @@ jobs:
       - nox-snapshot
     uses: fluencelabs/js-client/.github/workflows/tests.yml@main
     with:
-      ref: js-client-v0.9.0
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
 
   aqua:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5418,6 +5418,7 @@ dependencies = [
  "tracing-log",
  "tracing-logfmt",
  "tracing-opentelemetry",
+ "tracing-panic",
  "tracing-subscriber",
  "workers",
 ]
@@ -8312,6 +8313,16 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
+]
+
+[[package]]
+name = "tracing-panic"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf80030ce049691c9922d75be63cadf345110a245cd4581833c66f87c02ad25"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/created-swarm/src/swarm.rs
+++ b/crates/created-swarm/src/swarm.rs
@@ -46,7 +46,7 @@ use server_config::{
     UnresolvedConfig,
 };
 use tempfile::TempDir;
-use test_constants::{EXECUTION_TIMEOUT, TRANSPORT_TIMEOUT};
+use test_constants::{EXECUTION_TIMEOUT, IDLE_CONNECTION_TIMEOUT, TRANSPORT_TIMEOUT};
 use tokio::sync::oneshot;
 use toy_vms::EasyVM;
 use tracing::{Instrument, Span};
@@ -403,6 +403,7 @@ pub async fn create_swarm_with_runtime<RT: AquaRuntime>(
 
         resolved.node_config.aquavm_pool_size = config.pool_size.unwrap_or(1);
         resolved.node_config.particle_execution_timeout = EXECUTION_TIMEOUT;
+        resolved.node_config.transport_config.connection_idle_timeout = IDLE_CONNECTION_TIMEOUT;
 
         let allowed_effectors = config.allowed_effectors.iter().map(|(cid, binaries)| {
             (Hash::from_string(cid).unwrap(), binaries.clone())

--- a/crates/nox-tests/tests/workers.rs
+++ b/crates/nox-tests/tests/workers.rs
@@ -158,6 +158,9 @@ async fn test_resolve_subnet_on_worker() {
         );
         let mut object_map = serde_json::Map::new();
         object_map.insert("error".to_string(), error);
+        object_map.insert("success".to_string(), Value::Bool(false));
+        object_map.insert("workers".to_string(), Value::Array(vec![]));
+
         vec![Value::Object(object_map)]
     };
 

--- a/crates/nox-tests/tests/workers.rs
+++ b/crates/nox-tests/tests/workers.rs
@@ -153,7 +153,7 @@ async fn test_resolve_subnet_on_worker() {
         .unwrap();
 
     let expected = {
-        let error =    Value::Array(
+        let error = Value::Array(
             vec![Value::String("error sending jsonrpc request: 'Networking or low-level protocol error: Server returned an error status code: 429'".to_string())]
         );
         let mut object_map = serde_json::Map::new();

--- a/crates/nox-tests/tests/workers.rs
+++ b/crates/nox-tests/tests/workers.rs
@@ -154,7 +154,7 @@ async fn test_resolve_subnet_on_worker() {
 
     let expected = {
         let error =    Value::Array(
-            vec![Value::String("error sending jsonrpc request: 'Networking or low-level protocol error: Server returned an error status code: 429".to_string())]
+            vec![Value::String("error sending jsonrpc request: 'Networking or low-level protocol error: Server returned an error status code: 429'".to_string())]
         );
         let mut object_map = serde_json::Map::new();
         object_map.insert("error".to_string(), error);

--- a/crates/nox-tests/tests/workers/test_subnet_resolve_on_worker.air
+++ b/crates/nox-tests/tests/workers/test_subnet_resolve_on_worker.air
@@ -1,0 +1,13 @@
+(xor
+       (seq
+             (call -relay- ("op" "noop") [])
+             (seq
+                 (call -worker_id- ("op" "noop") [])
+                 (seq
+                    (call -worker_id- ("subnet" "resolve") [-deal_id-] subnet)
+                    (call %init_peer_id% ("op" "return") [subnet])
+                 )
+             )
+       )
+       (call %init_peer_id% ("op" "return") [%last_error%.$.instruction])
+)

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -49,7 +49,7 @@ pub fn default_socket_timeout() -> Duration {
 }
 
 pub fn default_connection_idle_timeout() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_secs(60)
 }
 
 pub fn default_max_established_per_peer_limit() -> Option<u32> {

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -49,7 +49,7 @@ pub fn default_socket_timeout() -> Duration {
 }
 
 pub fn default_connection_idle_timeout() -> Duration {
-    Duration::from_secs(60)
+    Duration::from_secs(180)
 }
 
 pub fn default_max_established_per_peer_limit() -> Option<u32> {

--- a/crates/server-config/src/defaults.rs
+++ b/crates/server-config/src/defaults.rs
@@ -49,6 +49,7 @@ pub fn default_socket_timeout() -> Duration {
 }
 
 pub fn default_connection_idle_timeout() -> Duration {
+    // 180 seconds makes sense because default Particle TTL is 120 sec, and it doesn't seem very efficient for hosts to reconnect while particle is still in flight
     Duration::from_secs(180)
 }
 

--- a/crates/test-constants/src/lib.rs
+++ b/crates/test-constants/src/lib.rs
@@ -35,6 +35,6 @@ pub static TIMEOUT: Duration = Duration::from_secs(15);
 
 pub static SHORT_TIMEOUT: Duration = Duration::from_millis(300);
 pub static TRANSPORT_TIMEOUT: Duration = Duration::from_millis(500);
-pub static IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
+pub static IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 pub static EXECUTION_TIMEOUT: Duration = Duration::from_millis(5000);
 pub static PARTICLE_TTL: u32 = 20000;

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -8,7 +8,7 @@ use core_manager::types::{AcquireRequest, WorkType};
 use core_manager::CUID;
 use fluence_libp2p::PeerId;
 use parking_lot::RwLock;
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::{Handle, Runtime, UnhandledPanic};
 use types::peer_scope::WorkerId;
 use types::DealId;
 
@@ -140,9 +140,12 @@ impl Workers {
             .worker_threads(threads_count)
             // Configuring blocking threads for handling I/O
             .max_blocking_threads(threads_count)
+            .enable_time()
+            .enable_io()
             .on_thread_start(move || {
                 assignment.pin_current_thread();
             })
+            .unhandled_panic(UnhandledPanic::Ignore) // TODO: try to log panics after fix https://github.com/tokio-rs/tokio/issues/4516
             .build()
             .map_err(|err| WorkersError::CreateRuntime { worker_id, err })?;
         Ok(runtime)

--- a/nox/Cargo.toml
+++ b/nox/Cargo.toml
@@ -72,6 +72,7 @@ once_cell = { workspace = true }
 config = "0.13.4"
 tonic = "0.9.2"
 jsonrpsee = { workspace = true, features = ["ws-client", "macros"] }
+tracing-panic = "0.1.1"
 
 [dev-dependencies]
 parking_lot = { workspace = true }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -281,7 +281,7 @@ where
             ("vault", "put") => wrap(self.vault_put(args, particle)),
             ("vault", "cat") => wrap(self.vault_cat(args, particle)),
 
-            ("subnet", "resolve") => wrap(self.subnet_resolve(args)),
+            ("subnet", "resolve") => wrap(self.subnet_resolve(args).await),
             ("run-console", "print") => {
                 let function_args = args.function_args.iter();
                 let decider = function_args.filter_map(JValue::as_str).any(|s| s.contains("decider"));
@@ -1037,10 +1037,10 @@ where
             .map_err(|_| JError::new(format!("Error reading vault file `{path}`")))
     }
 
-    fn subnet_resolve(&self, args: Args) -> Result<JValue, JError> {
+    async fn subnet_resolve(&self, args: Args) -> Result<JValue, JError> {
         let mut args = args.function_args.into_iter();
         let deal_id: String = Args::next("deal_id", &mut args)?;
-        let result = subnet_resolver::resolve_subnet(deal_id, &self.connector_api_endpoint);
+        let result = subnet_resolver::resolve_subnet(deal_id, &self.connector_api_endpoint).await;
         Ok(json!(result))
     }
 }


### PR DESCRIPTION
## Description
Fix crashing workers tokio runtime.

## Related Issue(s)
[Cite any related issues or feature requests here, using GitHub issue links.]

## Proposed Changes
- Added a panic hook
- Enabled io & timer drivers for the worker runtimes 
- Changed UnhandledPanic to Ignore for the worker runtimes
- Subnet resolve is async now
- increased default idle time to 180s

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

