### PR TITLE
fix(core-manager)!: use hex format for CUIDs [fixes NET-804]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "futures",
  "fxhash",
  "hex",
+ "hex-utils",
  "multimap 0.10.0",
  "newtype_derive",
  "num_cpus",
@@ -1666,6 +1667,7 @@ dependencies = [
  "rand 0.8.5",
  "range-set-blaze",
  "serde",
+ "serde_with 3.7.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3091,6 +3093,7 @@ name = "hex-utils"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "serde_with 3.7.0",
 ]
 
 [[package]]
@@ -7538,9 +7541,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -7550,7 +7553,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.6.1",
+ "serde_with_macros 3.7.0",
  "time",
 ]
 
@@ -7568,9 +7571,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7609,7 +7612,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "serde_with 3.6.1",
+ "serde_with 3.7.0",
  "temp-env",
  "tempfile",
  "toml 0.7.8",

--- a/crates/core-manager/Cargo.toml
+++ b/crates/core-manager/Cargo.toml
@@ -26,6 +26,9 @@ tracing.workspace = true
 tokio-stream.workspace = true
 futures.workspace = true
 rand = "0.8.5"
+hex.workspace = true
+serde_with = { workspace = true }
+hex-utils = { workspace = true, features = ["serde_with"] }
 
 
 [dev-dependencies]

--- a/crates/core-manager/src/core_range.rs
+++ b/crates/core-manager/src/core_range.rs
@@ -263,4 +263,12 @@ mod tests {
         let core_range_1: CoreRange = "0-2,5,7-9".parse().unwrap();
         assert_eq!(format!("{}", core_range_1), "0-2,5,7-9");
     }
+
+    #[test]
+    fn range_is_inclusive() {
+        let core_range_1: CoreRange = "1-3".parse().unwrap();
+        let actual: Vec<usize> = core_range_1.0.iter().collect();
+        let expected = vec![1, 2, 3];
+        assert_eq!(actual, expected)
+    }
 }

--- a/crates/core-manager/src/dev.rs
+++ b/crates/core-manager/src/dev.rs
@@ -204,12 +204,12 @@ impl From<&CoreManagerState> for PersistentCoreManagerState {
             unit_id_mapping: value
                 .core_unit_id_mapping
                 .iter()
-                .map(|(k, v)| (*k, v.clone().into()))
+                .map(|(k, v)| (*k, (*v)))
                 .collect(),
             work_type_mapping: value
                 .work_type_mapping
                 .iter()
-                .map(|(k, v)| (k.clone().into(), v.clone()))
+                .map(|(k, v)| ((*k), v.clone()))
                 .collect(),
         }
     }

--- a/crates/core-manager/src/dev.rs
+++ b/crates/core-manager/src/dev.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeSet, HashMap, VecDeque};
-use std::fs::File;
 use std::hash::BuildHasherDefault;
-use std::io::Write;
 use std::ops::Deref;
 use std::path::PathBuf;
 
@@ -10,11 +8,12 @@ use cpu_utils::CPUTopology;
 use fxhash::{FxBuildHasher, FxHasher};
 use parking_lot::RwLock;
 use range_set_blaze::RangeSetBlaze;
-use serde::{Deserialize, Serialize};
 
-use crate::errors::{AcquireError, CreateError, LoadingError, PersistError};
+use crate::errors::{AcquireError, CreateError, CurrentAssignment, LoadingError, PersistError};
 use crate::manager::CoreManagerFunctions;
-use crate::persistence::{PersistenceTask, PersistentCoreManagerFunctions};
+use crate::persistence::{
+    PersistenceTask, PersistentCoreManagerFunctions, PersistentCoreManagerState,
+};
 use crate::types::{AcquireRequest, Assignment, WorkType};
 use crate::CoreRange;
 
@@ -196,15 +195,6 @@ struct CoreManagerState {
     work_type_mapping: Map<CUID, WorkType>,
 }
 
-#[derive(Serialize, Deserialize)]
-struct PersistentCoreManagerState {
-    cores_mapping: Vec<(PhysicalCoreId, LogicalCoreId)>,
-    system_cores: Vec<PhysicalCoreId>,
-    available_cores: Vec<PhysicalCoreId>,
-    unit_id_mapping: Vec<(PhysicalCoreId, CUID)>,
-    work_type_mapping: Vec<(CUID, WorkType)>,
-}
-
 impl From<&CoreManagerState> for PersistentCoreManagerState {
     fn from(value: &CoreManagerState) -> Self {
         Self {
@@ -214,12 +204,12 @@ impl From<&CoreManagerState> for PersistentCoreManagerState {
             unit_id_mapping: value
                 .core_unit_id_mapping
                 .iter()
-                .map(|(k, v)| (*k, *v))
+                .map(|(k, v)| (*k, v.clone().into()))
                 .collect(),
             work_type_mapping: value
                 .work_type_mapping
                 .iter()
-                .map(|(k, v)| (*k, v.clone()))
+                .map(|(k, v)| (k.clone().into(), v.clone()))
                 .collect(),
         }
     }
@@ -261,7 +251,9 @@ impl CoreManagerFunctions for DevCoreManager {
                             .iter()
                             .map(|(k, v)| (*k, *v))
                             .collect();
-                        AcquireError::NotFoundAvailableCores { current_assignment }
+                        AcquireError::NotFoundAvailableCores {
+                            current_assignment: CurrentAssignment::new(current_assignment),
+                        }
                     })?;
                     lock.core_unit_id_mapping.insert(core_id, unit_id);
                     lock.unit_id_core_mapping.insert(unit_id, core_id);
@@ -342,12 +334,7 @@ impl PersistentCoreManagerFunctions for DevCoreManager {
         let inner_state = lock.deref();
         let persistent_state: PersistentCoreManagerState = inner_state.into();
         drop(lock);
-        let toml = toml::to_string_pretty(&persistent_state)
-            .map_err(|err| PersistError::SerializationError { err })?;
-        let mut file =
-            File::create(self.file_path.clone()).map_err(|err| PersistError::IoError { err })?;
-        file.write(toml.as_bytes())
-            .map_err(|err| PersistError::IoError { err })?;
+        persistent_state.persist(self.file_path.as_path())?;
         Ok(())
     }
 }

--- a/crates/core-manager/src/errors.rs
+++ b/crates/core-manager/src/errors.rs
@@ -1,5 +1,6 @@
 use ccp_shared::types::CUID;
 use cpu_utils::{CPUTopologyError, PhysicalCoreId};
+use std::fmt::{Display, Formatter, Write};
 use std::str::Utf8Error;
 use thiserror::Error;
 
@@ -58,12 +59,40 @@ pub enum PersistError {
     },
 }
 
+#[derive(Debug)]
+pub struct CurrentAssignment {
+    data: Vec<(PhysicalCoreId, CUID)>,
+}
+
+impl CurrentAssignment {
+    pub fn new(data: Vec<(PhysicalCoreId, CUID)>) -> Self {
+        Self { data }
+    }
+}
+
+impl Display for CurrentAssignment {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_char('[')?;
+        for (core, cuid) in &self.data[0..self.data.len() - 1] {
+            f.write_str(core.to_string().as_str())?;
+            f.write_str(" -> ")?;
+            f.write_str(format!("{}", cuid).as_str())?;
+            f.write_str(", ")?;
+        }
+        let (core, cuid) = &self.data[self.data.len() - 1];
+        f.write_str(core.to_string().as_str())?;
+        f.write_str(" -> ")?;
+        f.write_str(format!("{}", cuid).as_str())?;
+
+        f.write_char(']')?;
+        Ok(())
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum AcquireError {
-    #[error(
-        "Couldn't assign core: no free cores left. Current assignment: {current_assignment:?}"
-    )]
+    #[error("Couldn't assign core: no free cores left. Current assignment: {current_assignment}")]
     NotFoundAvailableCores {
-        current_assignment: Vec<(PhysicalCoreId, CUID)>,
+        current_assignment: CurrentAssignment,
     },
 }

--- a/crates/core-manager/src/persistence.rs
+++ b/crates/core-manager/src/persistence.rs
@@ -1,10 +1,18 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
 use std::sync::Arc;
 
+use ccp_shared::types::{LogicalCoreId, PhysicalCoreId, CUID};
 use futures::StreamExt;
+use hex_utils::serde_as::Hex;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use tokio::sync::mpsc::Receiver;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::errors::PersistError;
+use crate::types::WorkType;
 use crate::CoreManager;
 
 pub trait PersistentCoreManagerFunctions {
@@ -58,5 +66,66 @@ impl PersistenceTask {
             .name("core-manager-persist")
             .spawn(Self::process_events(stream, core_manager))
             .expect("Could not spawn persist task");
+    }
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct PersistentCoreManagerState {
+    pub cores_mapping: Vec<(PhysicalCoreId, LogicalCoreId)>,
+    pub system_cores: Vec<PhysicalCoreId>,
+    pub available_cores: Vec<PhysicalCoreId>,
+    #[serde_as(as = "Vec<(_, Hex)>")]
+    pub unit_id_mapping: Vec<(PhysicalCoreId, CUID)>,
+    #[serde_as(as = "Vec<(Hex, _)>")]
+    pub work_type_mapping: Vec<(CUID, WorkType)>,
+}
+
+impl PersistentCoreManagerState {
+    pub fn persist(&self, file_path: &Path) -> Result<(), PersistError> {
+        let toml = toml::to_string_pretty(&self)
+            .map_err(|err| PersistError::SerializationError { err })?;
+        let mut file = File::create(file_path).map_err(|err| PersistError::IoError { err })?;
+        file.write(toml.as_bytes())
+            .map_err(|err| PersistError::IoError { err })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::persistence::PersistentCoreManagerState;
+    use crate::types::WorkType;
+    use ccp_shared::types::{LogicalCoreId, PhysicalCoreId, CUID};
+    use hex::FromHex;
+
+    #[test]
+    fn test_serde() {
+        let init_id_1 =
+            <CUID>::from_hex("54ae1b506c260367a054f80800a545f23e32c6bc4a8908c9a794cb8dad23e5ea")
+                .unwrap();
+        let persistent_state = PersistentCoreManagerState {
+            cores_mapping: vec![
+                (PhysicalCoreId::new(1), LogicalCoreId::new(1)),
+                (PhysicalCoreId::new(1), LogicalCoreId::new(2)),
+                (PhysicalCoreId::new(2), LogicalCoreId::new(3)),
+                (PhysicalCoreId::new(2), LogicalCoreId::new(4)),
+                (PhysicalCoreId::new(3), LogicalCoreId::new(5)),
+                (PhysicalCoreId::new(3), LogicalCoreId::new(6)),
+                (PhysicalCoreId::new(4), LogicalCoreId::new(7)),
+                (PhysicalCoreId::new(4), LogicalCoreId::new(8)),
+            ],
+            system_cores: vec![PhysicalCoreId::new(1)],
+            available_cores: vec![PhysicalCoreId::new(2), PhysicalCoreId::new(3)],
+            unit_id_mapping: vec![(PhysicalCoreId::new(4), init_id_1.into())],
+            work_type_mapping: vec![(init_id_1.into(), WorkType::Deal)],
+        };
+        let actual = toml::to_string(&persistent_state).unwrap();
+        let expected = "cores_mapping = [[1, 1], [1, 2], [2, 3], [2, 4], [3, 5], [3, 6], [4, 7], [4, 8]]\n\
+        system_cores = [1]\n\
+        available_cores = [2, 3]\n\
+        unit_id_mapping = [[4, \"54ae1b506c260367a054f80800a545f23e32c6bc4a8908c9a794cb8dad23e5ea\"]]\n\
+        work_type_mapping = [[\"54ae1b506c260367a054f80800a545f23e32c6bc4a8908c9a794cb8dad23e5ea\", \"Deal\"]]\n";
+        assert_eq!(expected, actual)
     }
 }

--- a/crates/core-manager/src/persistence.rs
+++ b/crates/core-manager/src/persistence.rs
@@ -117,8 +117,8 @@ mod tests {
             ],
             system_cores: vec![PhysicalCoreId::new(1)],
             available_cores: vec![PhysicalCoreId::new(2), PhysicalCoreId::new(3)],
-            unit_id_mapping: vec![(PhysicalCoreId::new(4), init_id_1.into())],
-            work_type_mapping: vec![(init_id_1.into(), WorkType::Deal)],
+            unit_id_mapping: vec![(PhysicalCoreId::new(4), init_id_1)],
+            work_type_mapping: vec![(init_id_1, WorkType::Deal)],
         };
         let actual = toml::to_string(&persistent_state).unwrap();
         let expected = "cores_mapping = [[1, 1], [1, 2], [2, 3], [2, 4], [3, 5], [3, 6], [4, 7], [4, 8]]\n\

--- a/crates/core-manager/src/strict.rs
+++ b/crates/core-manager/src/strict.rs
@@ -200,12 +200,12 @@ impl From<&CoreManagerState> for PersistentCoreManagerState {
             unit_id_mapping: value
                 .unit_id_mapping
                 .iter()
-                .map(|(k, v)| (*k, v.clone().into()))
+                .map(|(k, v)| (*k, (*v)))
                 .collect(),
             work_type_mapping: value
                 .work_type_mapping
                 .iter()
-                .map(|(k, v)| (k.clone().into(), v.clone()))
+                .map(|(k, v)| ((*k), v.clone()))
                 .collect(),
         }
     }

--- a/crates/hex-utils/Cargo.toml
+++ b/crates/hex-utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+serde_with = ["dep:serde_with"]
 
 [dependencies]
 hex = { workspace = true }
+serde_with = { workspace = true, optional = true }

--- a/crates/hex-utils/src/lib.rs
+++ b/crates/hex-utils/src/lib.rs
@@ -2,3 +2,60 @@ pub fn decode_hex(h: &str) -> Result<Vec<u8>, hex::FromHexError> {
     let h = h.trim_start_matches("0x");
     hex::decode(h)
 }
+
+#[cfg(feature = "serde_with")]
+pub mod serde_as {
+    use core::fmt;
+    use hex::{FromHex, ToHex};
+    use serde_with::__private__::{DeError, Visitor};
+    use serde_with::serde::{Deserializer, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+    use std::fmt::Display;
+    use std::marker::PhantomData;
+
+    pub struct Hex;
+    impl<T> SerializeAs<T> for Hex
+    where
+        T: ToHex,
+    {
+        fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.collect_str(source.encode_hex::<String>().as_str())
+        }
+    }
+
+    impl<'de, T> DeserializeAs<'de, T> for Hex
+    where
+        T: FromHex,
+        T::Error: Display,
+    {
+        fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct Helper<S>(PhantomData<S>);
+            impl<'de, S> Visitor<'de> for Helper<S>
+            where
+                S: FromHex,
+                <S as FromHex>::Error: Display,
+            {
+                type Value = S;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("a string")
+                }
+
+                fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                where
+                    E: DeError,
+                {
+                    Self::Value::from_hex(value.as_bytes()).map_err(DeError::custom)
+                }
+            }
+
+            deserializer.deserialize_str(Helper(PhantomData))
+        }
+    }
+}


### PR DESCRIPTION

## Description
Use hex format for CUIDs instead of byre arrays. 

## Motivation
Byte arrays aren't human-readable

## Related Issue(s)

[NET-804](https://linear.app/fluence/issue/NET-804/make-cuid-human-readable)

## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

