### PR TITLE
feat(metrics): add metrics in chain-listener [NET-806]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,6 +1369,7 @@ dependencies = [
  "libipld",
  "libp2p-identity",
  "log",
+ "peer-metrics",
  "serde",
  "serde_json",
  "server-config",

--- a/crates/chain-listener/Cargo.toml
+++ b/crates/chain-listener/Cargo.toml
@@ -39,6 +39,7 @@ ccp-shared = { workspace = true }
 tokio-stream = { workspace = true }
 toml_edit = { workspace = true }
 backoff = { version = "0.4.0", features = ["tokio", "futures"] }
+peer-metrics = { workspace = true }
 
 [dev-dependencies]
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/crates/chain-listener/src/lib.rs
+++ b/crates/chain-listener/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(try_blocks)]
 #![feature(extract_if)]
 #![feature(btree_extract_if)]
+#![feature(result_option_inspect)]
+#![feature(async_closure)]
 
 extern crate core;
 

--- a/crates/chain-listener/src/lib.rs
+++ b/crates/chain-listener/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(extract_if)]
 #![feature(btree_extract_if)]
 #![feature(result_option_inspect)]
-#![feature(async_closure)]
 
 extern crate core;
 

--- a/crates/chain-listener/src/listener.rs
+++ b/crates/chain-listener/src/listener.rs
@@ -1283,7 +1283,10 @@ fn all_max_proofs_found(non_priority_units: &[CUID]) -> bool {
 }
 
 // measure the request execution time and store it in the metrics
-async fn measured_request<Fut, R, E>(metrics: &Option<ChainListenerMetrics>, fut: Fut) -> Result<R, E>
+async fn measured_request<Fut, R, E>(
+    metrics: &Option<ChainListenerMetrics>,
+    fut: Fut,
+) -> Result<R, E>
 where
     Fut: Future<Output = Result<R, E>> + Sized,
 {

--- a/crates/peer-metrics/src/chain_listener.rs
+++ b/crates/peer-metrics/src/chain_listener.rs
@@ -1,0 +1,155 @@
+use crate::{execution_time_buckets, register};
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::exemplar::CounterWithExemplar;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+
+#[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+struct BlockLabel {
+    block_number: String,
+}
+
+#[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+struct TxLabel {
+    tx_hash: String,
+}
+
+#[derive(Clone)]
+pub struct ChainListenerMetrics {
+    // how many request Nox sends to ccp
+    ccp_requests_total: Counter,
+    // how many success replies Nox receives from ccp
+    // an error is either error from ccp or connection errors
+    ccp_replies_total: Counter,
+    // how long we wait for a reply from ccp
+    ccp_request_duration_msec: Histogram,
+    // how many proofs we submitted
+    cpp_proofs_submitted: Counter,
+    // how many proofs we failed to submit
+    cpp_proofs_submit_failed: Counter,
+    // how many proofs transaction are ok
+    ccp_proofs_tx_success: Counter,
+    // how many proofs transaction are failed
+    ccp_proofs_tx_failed: CounterWithExemplar<TxLabel>,
+    // How many blocks we have received from the newHead subscription
+    blocks_seen: CounterWithExemplar<BlockLabel>,
+    // How many block we manage to process while processing the block
+    blocks_processed: Counter,
+}
+
+impl ChainListenerMetrics {
+    pub fn new(registry: &mut Registry) -> Self {
+        let sub_registry = registry.sub_registry_with_prefix("chain_listener");
+
+        let ccp_requests_total = register(
+            sub_registry,
+            Counter::default(),
+            "ccp_requests_total",
+            "Total number of requests sent to ccp",
+        );
+
+        let ccp_replies_total = register(
+            sub_registry,
+            Counter::default(),
+            "ccp_replies_total",
+            "Total number of successful replies from ccp",
+        );
+
+        let ccp_request_duration_msec = register(
+            sub_registry,
+            Histogram::new(execution_time_buckets()),
+            "ccp_request_duration",
+            "Duration of ccp requests",
+        );
+
+        let cpp_proofs_submitted = register(
+            sub_registry,
+            Counter::default(),
+            "cpp_proofs_submitted",
+            "Total number of proofs submitted to ccp",
+        );
+
+        let cpp_proofs_submit_failed = register(
+            sub_registry,
+            Counter::default(),
+            "cpp_proofs_submit_failed",
+            "Total number of proofs we failed to submit to ccp",
+        );
+
+        let ccp_proofs_tx_success = register(
+            sub_registry,
+            Counter::default(),
+            "ccp_proofs_tx_success",
+            "Total number of successfully processed proofs (transaction is ok)",
+        );
+
+        let ccp_proofs_tx_failed = register(
+            sub_registry,
+            CounterWithExemplar::default(),
+            "ccp_proofs_tx_failed",
+            "Total number of failed proofs (transaction isn't ok)",
+        );
+
+        let blocks_seen = register(
+            sub_registry,
+            CounterWithExemplar::default(),
+            "blocks_seen",
+            "Total number of blocks seen from the newHead subscription",
+        );
+
+        let blocks_processed = register(
+            sub_registry,
+            Counter::default(),
+            "blocks_processed",
+            "Total number of blocks processed",
+        );
+
+        Self {
+            ccp_requests_total,
+            ccp_replies_total,
+            ccp_request_duration_msec,
+            cpp_proofs_submitted,
+            cpp_proofs_submit_failed,
+            ccp_proofs_tx_success,
+            ccp_proofs_tx_failed,
+            blocks_seen,
+            blocks_processed,
+        }
+    }
+
+    pub fn observe_ccp_request(&self) {
+        self.ccp_requests_total.inc();
+    }
+
+    pub fn observe_ccp_reply(&self, duration: f64) {
+        self.ccp_replies_total.inc();
+        self.ccp_request_duration_msec.observe(duration);
+    }
+
+    pub fn observe_proof_failed(&self) {
+        self.cpp_proofs_submit_failed.inc();
+    }
+
+    pub fn observe_proof_submitted(&self) {
+        self.cpp_proofs_submitted.inc();
+    }
+
+    pub fn observe_proof_tx_success(&self) {
+        self.ccp_proofs_tx_success.inc();
+    }
+
+    pub fn observe_proof_tx_failed(&self, tx_hash: String) {
+        self.ccp_proofs_tx_failed
+            .inc_by(1, Some(TxLabel { tx_hash }));
+    }
+
+    pub fn observe_new_block(&self, block_number: String) {
+        self.blocks_seen
+            .inc_by(1, Some(BlockLabel { block_number }));
+    }
+
+    pub fn observe_processed_block(&self) {
+        self.blocks_processed.inc();
+    }
+}

--- a/crates/peer-metrics/src/chain_listener.rs
+++ b/crates/peer-metrics/src/chain_listener.rs
@@ -25,9 +25,9 @@ pub struct ChainListenerMetrics {
     // how long we wait for a reply from ccp
     ccp_request_duration_msec: Histogram,
     // how many proofs we submitted
-    cpp_proofs_submitted: Counter,
+    ccp_proofs_submitted: Counter,
     // how many proofs we failed to submit
-    cpp_proofs_submit_failed: Counter,
+    ccp_proofs_submit_failed: Counter,
     // how many proofs transaction are ok
     ccp_proofs_tx_success: Counter,
     // how many proofs transaction are failed
@@ -63,14 +63,14 @@ impl ChainListenerMetrics {
             "Duration of ccp requests",
         );
 
-        let cpp_proofs_submitted = register(
+        let ccp_proofs_submitted = register(
             sub_registry,
             Counter::default(),
             "cpp_proofs_submitted",
             "Total number of proofs submitted to ccp",
         );
 
-        let cpp_proofs_submit_failed = register(
+        let ccp_proofs_submit_failed = register(
             sub_registry,
             Counter::default(),
             "cpp_proofs_submit_failed",
@@ -109,8 +109,8 @@ impl ChainListenerMetrics {
             ccp_requests_total,
             ccp_replies_total,
             ccp_request_duration_msec,
-            cpp_proofs_submitted,
-            cpp_proofs_submit_failed,
+            ccp_proofs_submitted,
+            ccp_proofs_submit_failed,
             ccp_proofs_tx_success,
             ccp_proofs_tx_failed,
             blocks_seen,
@@ -128,11 +128,11 @@ impl ChainListenerMetrics {
     }
 
     pub fn observe_proof_failed(&self) {
-        self.cpp_proofs_submit_failed.inc();
+        self.ccp_proofs_submit_failed.inc();
     }
 
     pub fn observe_proof_submitted(&self) {
-        self.cpp_proofs_submitted.inc();
+        self.ccp_proofs_submitted.inc();
     }
 
     pub fn observe_proof_tx_success(&self) {

--- a/crates/peer-metrics/src/lib.rs
+++ b/crates/peer-metrics/src/lib.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, EncodeMetric};
 use prometheus_client::registry::Registry;
 
+pub use chain_listener::ChainListenerMetrics;
 pub use connection_pool::ConnectionPoolMetrics;
 pub use connectivity::ConnectivityMetrics;
 pub use connectivity::Resolution;
@@ -17,6 +18,7 @@ pub use services_metrics::{
 pub use spell_metrics::SpellMetrics;
 pub use vm_pool::VmPoolMetrics;
 
+mod chain_listener;
 mod connection_pool;
 mod connectivity;
 mod dispatcher;

--- a/crates/peer-metrics/src/spell_metrics.rs
+++ b/crates/peer-metrics/src/spell_metrics.rs
@@ -8,7 +8,7 @@ use prometheus_client::registry::Registry;
 pub struct SpellMetrics {
     // How much spell _particles_ were created by the node
     spell_particles_created: Counter,
-    // How much spells are scheduled to run _now_
+    // How many spells are scheduled to run _now_
     spell_scheduled_now: Gauge,
     // Distribution of spell's scheduled periods
     spell_periods: Histogram,


### PR DESCRIPTION
## Description

Add some metrics to the ChainListener module. 

## Proposed Changes
Add a pack of metrics:
```rust
pub struct ChainListenerMetrics {
    // how many request Nox sends to ccp
    ccp_requests_total: Counter,
    // how many success replies Nox receives from ccp
    // an error is either error from ccp or connection errors
    ccp_replies_total: Counter,
    // how long we wait for a reply from ccp
    ccp_request_duration_msec: Histogram,
    // how many proofs we submitted
    cpp_proofs_submitted: Counter,
    // how many proofs we failed to submit
    cpp_proofs_submit_failed: Counter,
    // how many proofs transaction are ok
    ccp_proofs_tx_success: Counter,
    // how many proofs transaction are failed
    ccp_proofs_tx_failed: CounterWithExemplar<TxLabel>,
    // How many blocks we have received from the newHead subscription
    blocks_seen: CounterWithExemplar<BlockLabel>,
    // How many block we manage to process while processing the block
    blocks_processed: Counter,
}
```

## Additional Notes

We were discussing some refactoring, and I did the tiniest amount of refactoring, but I think we should do it in a separate PR. 

