### PR TITLE
fix(renovate): effectively disable automatic Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   ],
   "allowCustomCrateRegistries": "true",
   "enabledManagers": ["cargo", "github-actions"],
-  "schedule": "every weekend",
+  "schedule": "every 12 years",
   "packageRules": [
     {
       "matchManagers": ["cargo"],


### PR DESCRIPTION
I want to disable automatic Renovate PRs creation, as they spam and make it hard to review the repo's PRs list.

But we will keep the Dashboard (https://github.com/fluencelabs/nox/issues/1304), so any update can be done manually

P.S. I think we still want automatic PRs for libs and components by Fluence Labs, let me figure that out