### PR TITLE
fix(chain-listener): reset proof counters on new epoch in refresh [NET-813]

### DIFF
--- a/crates/chain-listener/src/listener.rs
+++ b/crates/chain-listener/src/listener.rs
@@ -288,15 +288,17 @@ impl ChainListener {
                     err
                 })?;
 
+        tracing::info!(target: "chain-listener","Commitment initial params: difficulty {}, global nonce {}, init_timestamp {}, epoch_duration {}, current_epoch {}, min_proofs_per_epoch {}, max_proofs_per_epoch {}",  init_params.difficulty, init_params.global_nonce, init_params.init_timestamp, init_params.epoch_duration, init_params.current_epoch, init_params.min_proofs_per_epoch, init_params.max_proofs_per_epoch);
+
         self.difficulty = init_params.difficulty;
         self.init_timestamp = init_params.init_timestamp;
         self.global_nonce = init_params.global_nonce;
         self.epoch_duration = init_params.epoch_duration;
-        self.current_epoch = init_params.current_epoch;
         self.min_proofs_per_epoch = init_params.min_proofs_per_epoch;
         self.max_proofs_per_epoch = init_params.max_proofs_per_epoch;
 
-        tracing::info!(target: "chain-listener","Commitment initial params: difficulty {}, global nonce {}, init_timestamp {}, epoch_duration {}, current_epoch {}, min_proofs_per_epoch {}, max_proofs_per_epoch {}",  init_params.difficulty, init_params.global_nonce, init_params.init_timestamp, init_params.epoch_duration, init_params.current_epoch, init_params.min_proofs_per_epoch, init_params.max_proofs_per_epoch);
+        self.set_current_epoch(init_params.current_epoch);
+
         Ok(())
     }
 
@@ -359,6 +361,7 @@ impl ChainListener {
     }
 
     async fn reset_proof_id(&mut self) -> eyre::Result<()> {
+        tracing::info!(target: "chain-listener", "Resetting proof id counter");
         self.set_proof_id(ProofIdx::zero()).await
     }
 
@@ -657,7 +660,6 @@ impl ChainListener {
 
         if epoch_changed {
             // TODO: add epoch_number to metrics
-            tracing::info!(target: "chain-listener", "Epoch changed, new epoch number: {epoch_number}");
 
             // nonce changes every epoch
             self.global_nonce = self.chain_connector.get_global_nonce().await?;
@@ -666,10 +668,8 @@ impl ChainListener {
                 self.global_nonce
             );
 
-            self.current_epoch = epoch_number;
-            tracing::info!(target: "chain-listener", "Resetting proof id counter");
+            self.set_current_epoch(epoch_number);
             self.reset_proof_id().await?;
-            self.proof_counter.clear();
 
             if let Some(status) = self.get_commitment_status().await? {
                 tracing::info!(target: "chain-listener", "Current commitment status: {status:?}");
@@ -1319,6 +1319,14 @@ impl ChainListener {
         }
 
         Ok(())
+    }
+
+    fn set_current_epoch(&mut self, epoch_number: U256) {
+        if self.current_epoch != epoch_number {
+            tracing::info!(target: "chain-listener", "Epoch changed, was {}, new epoch number is {epoch_number}", self.current_epoch);
+            self.current_epoch = epoch_number;
+            self.proof_counter.clear();
+        }
     }
 
     fn observe<F>(&self, f: F)


### PR DESCRIPTION
## Description
Clear proof counters in case of epoch change inside refresh method. 
 
## Motivation
Otherwise, in case of websocket disconnect and epoch change peer won't reset proof counters and won't send any proofs.


## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

