### PR TITLE
chore: remove refs to branches in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,6 @@ jobs:
       - nox-snapshot
     uses: fluencelabs/cli/.github/workflows/tests.yml@main
     with:
-      ref: change-nox-config
       nox-image: "${{ needs.nox-snapshot.outputs.nox-image }}"
 
 


### PR DESCRIPTION
This PR should be merged only after the `change-nox-config` is merged, because the changes in the branch are required for the FCLI tests to pass.