### PR TITLE
fix(dev-mode): change effector config usage in dev-mode

### DIFF
--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -121,6 +121,8 @@ where
         } else {
             EffectorsMode::restricted_effectors(config.allowed_effectors.clone())
         };
+        let is_dev_mode = config.is_dev_mode;
+
         let modules = ModuleRepository::new(modules_dir, blueprint_dir, effectors_mode);
         let services = ParticleAppServices::new(
             config,
@@ -140,7 +142,7 @@ where
             key_storage,
             scopes: scope,
             connector_api_endpoint,
-            is_dev_mode: config.is_dev_mode,
+            is_dev_mode,
         }
     }
 

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -94,6 +94,7 @@ pub struct Builtins<C> {
     #[derivative(Debug = "ignore")]
     scopes: PeerScopes,
     connector_api_endpoint: String,
+    is_dev_mode: bool,
 }
 
 impl<C> Builtins<C>
@@ -113,13 +114,12 @@ where
         let modules_dir = &config.modules_dir;
         let blueprint_dir = &config.blueprint_dir;
         let effectors_mode = if config.is_dev_mode {
-            EffectorsMode::AllEffectors {
-                binaries: config.mounted_binaries_mapping.clone(),
-            }
+            EffectorsMode::all_effectors(
+                config.allowed_effectors.clone(),
+                config.mounted_binaries_mapping.clone(),
+            )
         } else {
-            EffectorsMode::RestrictedEffectors {
-                effectors: config.allowed_effectors.clone(),
-            }
+            EffectorsMode::restricted_effectors(config.allowed_effectors.clone())
         };
         let modules = ModuleRepository::new(modules_dir, blueprint_dir, effectors_mode);
         let services = ParticleAppServices::new(
@@ -140,6 +140,7 @@ where
             key_storage,
             scopes: scope,
             connector_api_endpoint,
+            is_dev_mode: config.is_dev_mode,
         }
     }
 
@@ -303,11 +304,12 @@ where
             }
             // NOTE: must be the same as in ServiceKey::AquaIpfs
             // TODO: come up with some better way of restricting service access like aqua-ipfs
-            ("aqua-ipfs", _) => {
+            ("aqua-ipfs", _)  => {
                 // If the call is on Host, we check that the caller is a host, a manager or
-                // a worker spell. Otherwise we allow the call to go and find an aqua-ipfs service
+                // a worker spell. Otherwise, we allow the call to go and find an aqua-ipfs service
                 // since it can be a user-defined service which isn't the same as system aqua-ipfs.
-                if matches!(particle.peer_scope, PeerScope::Host) {
+                // Allow anything when in the Dev Mode
+                if !self.is_dev_mode && matches!(particle.peer_scope, PeerScope::Host) {
                     self.guard_protected(&particle).await?;
                 }
                 FunctionOutcome::NotDefined { args, params: particle }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -304,7 +304,7 @@ where
             }
             // NOTE: must be the same as in ServiceKey::AquaIpfs
             // TODO: come up with some better way of restricting service access like aqua-ipfs
-            ("aqua-ipfs", _)  => {
+            ("aqua-ipfs", _) => {
                 // If the call is on Host, we check that the caller is a host, a manager or
                 // a worker spell. Otherwise, we allow the call to go and find an aqua-ipfs service
                 // since it can be a user-defined service which isn't the same as system aqua-ipfs.


### PR DESCRIPTION
## Description

Change effectors loading in dev mode.

## Motivation

Now, in the dev mode, we use settings from `dev_mode.binaries` for the effectors's module configs, ignoring the `effectors` setting. To set it up, a user must manually edit Nox's config if they want their modules to use those binaries in the dev mode. That's hard and isn't supported by FCLI. However, FCLI support the `effectors` config, which is now ignored in the dev mode.

This PR, when Nox encounters a module which `effectors` configuration, it takes the config from there, not from `dev_mode.binaries`.

## Proposed Changes
- In the dev mode, if a module is configured as an effector, try to take config for it from `effectors`. If no effector is configured, try to take from the default list of binaries for a module.
- Also, allow anyone to use `aqua-ipfs` service in the dev mode. **Note that aqua-ipfs is still available only on host**.


## Testing

Only wrote tests in the `particle-module` crate, didn't try it with FCLI

