### PR TITLE
fix: suspend/resume on worker deactivate/activate

### DIFF
--- a/crates/vm-utils/src/lib.rs
+++ b/crates/vm-utils/src/lib.rs
@@ -2,9 +2,11 @@ mod vm_utils;
 
 pub use nonempty::NonEmpty;
 pub use vm_utils::create_domain;
+pub use vm_utils::pause_vm;
 pub use vm_utils::reboot_vm;
 pub use vm_utils::remove_domain;
 pub use vm_utils::reset_vm;
+pub use vm_utils::resume_vm;
 pub use vm_utils::start_vm;
 pub use vm_utils::status_vm;
 pub use vm_utils::stop_vm;

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -432,6 +432,7 @@ impl Workers {
     /// - `Err(WorkersError)` if an error occurs during the activation process.
     ///
     pub async fn activate_worker(&self, worker_id: WorkerId) -> Result<(), WorkersError> {
+        self.resume_vm(worker_id)?;
         self.set_worker_status(worker_id, true).await?;
         Ok(())
     }
@@ -452,6 +453,7 @@ impl Workers {
     /// - `Err(WorkersError)` if an error occurs during the deactivation process.
     ///
     pub async fn deactivate_worker(&self, worker_id: WorkerId) -> Result<(), WorkersError> {
+        self.pause_vm(worker_id)?;
         self.set_worker_status(worker_id, false).await?;
         Ok(())
     }
@@ -725,6 +727,28 @@ impl Workers {
 
     pub fn reset_vm(&self, worker_id: WorkerId) -> Result<(), WorkersError> {
         self.on_vm(worker_id, vm_utils::reset_vm)
+    }
+
+    fn pause_vm(&self, worker_id: WorkerId) -> Result<(), WorkersError> {
+        if let Some(vm_config) = &self.config.vm {
+            if self.has_vm(worker_id)? {
+                vm_utils::pause_vm(vm_config.libvirt_uri.as_str(), &worker_id.to_string())?;
+            } else {
+                return Err(WorkersError::VmNotFound(worker_id));
+            }
+        }
+        Ok(())
+    }
+
+    fn resume_vm(&self, worker_id: WorkerId) -> Result<(), WorkersError> {
+        if let Some(vm_config) = &self.config.vm {
+            if self.has_vm(worker_id)? {
+                vm_utils::resume_vm(vm_config.libvirt_uri.as_str(), &worker_id.to_string())?;
+            } else {
+                return Err(WorkersError::VmNotFound(worker_id));
+            }
+        }
+        Ok(())
     }
 
     pub fn status_vm(&self, worker_id: WorkerId) -> Result<VmStatus, WorkersError> {

--- a/crates/workers/src/workers.rs
+++ b/crates/workers/src/workers.rs
@@ -698,10 +698,12 @@ impl Workers {
 
     fn remove_vm(&self, worker_id: WorkerId) -> Result<(), WorkersError> {
         if let Some(vm_config) = &self.config.vm {
-            vm_utils::remove_domain(
-                vm_config.libvirt_uri.as_str(),
-                worker_id.to_string().as_str(),
-            )?;
+            if self.has_vm(worker_id)? {
+                vm_utils::remove_domain(
+                    vm_config.libvirt_uri.as_str(),
+                    worker_id.to_string().as_str(),
+                )?;
+            }
         }
         Ok(())
     }
@@ -733,8 +735,6 @@ impl Workers {
         if let Some(vm_config) = &self.config.vm {
             if self.has_vm(worker_id)? {
                 vm_utils::pause_vm(vm_config.libvirt_uri.as_str(), &worker_id.to_string())?;
-            } else {
-                return Err(WorkersError::VmNotFound(worker_id));
             }
         }
         Ok(())
@@ -744,8 +744,6 @@ impl Workers {
         if let Some(vm_config) = &self.config.vm {
             if self.has_vm(worker_id)? {
                 vm_utils::resume_vm(vm_config.libvirt_uri.as_str(), &worker_id.to_string())?;
-            } else {
-                return Err(WorkersError::VmNotFound(worker_id));
             }
         }
         Ok(())


### PR DESCRIPTION
## Description
Pause VMs on worker deactivation and resume on activation

## Motivation
To reflect the deal state on chain

## Additional Notes
- Tested manually, deactivation and activation worked as expected 
