### PR TITLE
feat(vm): extend peer.identify with vm connection info

### DIFF
--- a/crates/server-config/src/node_config.rs
+++ b/crates/server-config/src/node_config.rs
@@ -637,8 +637,10 @@ pub struct VmNetworkConfig {
     pub public_ip: Ipv4Addr,
     #[serde(default = "default_vm_ip")]
     pub vm_ip: Ipv4Addr,
+    // SSH port on the host machine to connect to the VM from outside
     #[serde(default = "default_host_ssh_port")]
     pub host_ssh_port: u16,
+    // SSH port inside the VM
     #[serde(default = "default_vm_ssh_port")]
     pub vm_ssh_port: u16,
     #[serde(default = "default_port_range_config")]

--- a/particle-builtins/src/identify.rs
+++ b/particle-builtins/src/identify.rs
@@ -18,7 +18,6 @@
  */
 use libp2p::core::Multiaddr;
 use serde::Serialize;
-use std::path::PathBuf;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct NodeInfo {
@@ -26,5 +25,34 @@ pub struct NodeInfo {
     pub node_version: &'static str,
     pub air_version: &'static str,
     pub spell_version: String,
-    pub allowed_binaries: Vec<PathBuf>,
+    pub allowed_effectors: Vec<String>,
+    pub vm_info: Option<VmInfo>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct VmInfo {
+    // Public IP via which we can connect to the VM
+    pub ip: String,
+    // List of ports that are forwarded to the VM
+    pub forwarded_ports: Vec<PortInfo>,
+    // Default SSH port to which to connect
+    pub default_ssh_port: u16,
+}
+
+#[derive(Clone, Debug)]
+pub enum PortInfo {
+    Port(u16),
+    Range(u16, u16),
+}
+
+impl Serialize for PortInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PortInfo::Port(port) => serializer.serialize_u16(*port),
+            PortInfo::Range(start, end) => serializer.serialize_str(&format!("{}-{}", start, end)),
+        }
+    }
 }

--- a/particle-builtins/src/lib.rs
+++ b/particle-builtins/src/lib.rs
@@ -33,7 +33,7 @@
 )]
 
 pub use builtins::{Builtins, BuiltinsConfig, CustomService};
-pub use identify::NodeInfo;
+pub use identify::{NodeInfo, PortInfo, VmInfo};
 pub use outcome::{ok, wrap, wrap_unit};
 pub use particle_services::ParticleAppServicesConfig;
 mod builtins;


### PR DESCRIPTION
## Description
Provide a way for users to know where to connect to.

## Proposed Changes

Extend `Peer.identify()` with new field `vm_info`:
```
{
    "node_version": "0.27.1",
    "spell_version": "0.7.5",
    "air_version": "0.63.0",
    "vm_info": {
      "default_ssh_port": 922,
      "forwarded_ports": [
        "1000-65535"
      ],
      "ip": "1.1.1.1"
    },
    "external_addresses": [],
    "allowed_effectors": [
      "bafkreids22lgia5bqs63uigw4mqwhsoxvtnkpfqxqy5uwyyerrldsr32ce"
    ]
  }
```
