### PR TITLE
feat(metrics): add chain info metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7907,7 +7907,6 @@ dependencies = [
  "maplit",
  "num_cpus",
  "particle-protocol",
- "peer-metrics",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/crates/chain-listener/src/listener.rs
+++ b/crates/chain-listener/src/listener.rs
@@ -451,6 +451,7 @@ impl ChainListener {
                 .chain_connector
                 .get_commitment_status(commitment_id)
                 .await?;
+            self.observe(|m| m.observe_commiment_status(status as u64));
             Ok(Some(status))
         } else {
             Ok(None)

--- a/crates/peer-metrics/src/chain_listener.rs
+++ b/crates/peer-metrics/src/chain_listener.rs
@@ -53,6 +53,7 @@ pub struct ChainListenerMetrics {
     // How many block we manage to process while processing the block
     blocks_processed: Counter,
     last_process_block: Gauge,
+    current_commitment_status: GaugeWithExemplar,
 }
 
 impl ChainListenerMetrics {
@@ -135,6 +136,13 @@ impl ChainListenerMetrics {
             "Last processed block from the newHead subscription",
         );
 
+        let current_commitment_status = register(
+            sub_registry,
+            Gauge::default(),
+            "current_commitment_status",
+            "Current commitment status",
+        );
+
         Self {
             ccp_requests_total,
             ccp_replies_total,
@@ -147,6 +155,7 @@ impl ChainListenerMetrics {
             last_seen_block,
             blocks_processed,
             last_process_block,
+            current_commitment_status,
         }
     }
 
@@ -184,5 +193,9 @@ impl ChainListenerMetrics {
     pub fn observe_processed_block(&self, block_number: u64) {
         self.blocks_processed.inc();
         self.last_process_block.set(block_number as i64);
+    }
+
+    pub fn observe_commiment_status(&self, status: u64) {
+        self.current_commitment_status.set(status as i64);
     }
 }

--- a/crates/peer-metrics/src/chain_listener.rs
+++ b/crates/peer-metrics/src/chain_listener.rs
@@ -53,7 +53,7 @@ pub struct ChainListenerMetrics {
     // How many block we manage to process while processing the block
     blocks_processed: Counter,
     last_process_block: Gauge,
-    current_commitment_status: GaugeWithExemplar,
+    current_commitment_status: Gauge,
 }
 
 impl ChainListenerMetrics {

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -100,35 +100,3 @@ pub fn add_info_metrics2(
     ]);
     sub_registry.register("build", "Nox Info", info);
 }
-
-#[test]
-fn test() {
-    let mut reg = Registry::default();
-    let info = NoxInfo {
-        versions: NoxVersions {
-            node_version: "0.1.0".to_string(),
-            air_version: "0.1.0".to_string(),
-            spell_version: "0.1.0".to_string(),
-        },
-        chain_info: ChainInfo {
-            peer_id: "0x123".to_string(),
-            http_endpoint: "http://localhost:8545".to_string(),
-            diamond_contract_address: "0x123".to_string(),
-            network_id: 1,
-            default_base_fee: Some(1),
-            default_priority_fee: Some(1),
-            ws_endpoint: "ws://localhost:8546".to_string(),
-            proof_poll_period_secs: 1,
-            min_batch_count: 1,
-            max_batch_count: 1,
-            max_proof_batch_size: 1,
-            epoch_end_window_secs: 1,
-        },
-    };
-    add_info_metrics(&mut reg, info);
-
-    let mut buf = String::new();
-
-    encode(&mut buf, &reg);
-    println!("{buf}");
-}

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -22,13 +22,13 @@ use prometheus_client::metrics::info::Info;
 use prometheus_client::registry::Registry;
 
 pub struct NoxInfo  {
-    pub versions: NoxVersions,
+    pub version: NoxVersion,
     pub chain_info: ChainInfo,
 }
 
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, EncodeLabelSet)]
-pub struct NoxVersions {
+pub struct NoxVersion {
     pub node_version: String,
     pub air_version: String,
     pub spell_version: String,
@@ -54,7 +54,7 @@ pub struct ChainInfo {
 }
 
 impl ChainInfo {
-    pub fn empty(peer_id: String) -> ChainInfo {
+    pub fn default(peer_id: String) -> ChainInfo {
         ChainInfo {
             peer_id,
             http_endpoint: "".to_string(),
@@ -78,25 +78,9 @@ pub fn add_info_metrics(
 ) {
     let sub_registry = registry.sub_registry_with_prefix("nox");
 
-    let info = Info::new(nox_info.versions);
+    let info = Info::new(nox_info.version);
     sub_registry.register("build", "Nox Info", info);
 
     let chain_info = Info::new(nox_info.chain_info);
     sub_registry.register("chain", "Chain Nox Info", chain_info);
-}
-
-pub fn add_info_metrics2(
-    registry: &mut Registry,
-    node_version: String,
-    air_version: String,
-    spell_version: String,
-) {
-    let sub_registry = registry.sub_registry_with_prefix("nox");
-
-    let info = Info::new(vec![
-        ("node_version", node_version),
-        ("air_version", air_version),
-        ("spell_version", spell_version),
-    ]);
-    sub_registry.register("build", "Nox Info", info);
 }

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -21,11 +21,10 @@ use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::info::Info;
 use prometheus_client::registry::Registry;
 
-pub struct NoxInfo  {
+pub struct NoxInfo {
     pub version: NoxVersion,
     pub chain_info: ChainInfo,
 }
-
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, EncodeLabelSet)]
 pub struct NoxVersion {
@@ -72,10 +71,7 @@ impl ChainInfo {
     }
 }
 
-pub fn add_info_metrics(
-    registry: &mut Registry,
-    nox_info: NoxInfo,
-) {
+pub fn add_info_metrics(registry: &mut Registry, nox_info: NoxInfo) {
     let sub_registry = registry.sub_registry_with_prefix("nox");
 
     let info = Info::new(nox_info.version);

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -17,20 +17,118 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::info::Info;
 use prometheus_client::registry::Registry;
 
+pub struct NoxInfo  {
+    pub versions: NoxVersions,
+    pub chain_info: ChainInfo,
+}
+
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, EncodeLabelSet)]
+pub struct NoxVersions {
+    pub node_version: String,
+    pub air_version: String,
+    pub spell_version: String,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, EncodeLabelSet)]
+pub struct ChainInfo {
+    pub peer_id: String,
+    // Connector Settings
+    pub http_endpoint: String,
+    pub diamond_contract_address: String,
+    pub network_id: u64,
+    pub default_base_fee: Option<u64>,
+    pub default_priority_fee: Option<u64>,
+
+    // Listener Settings
+    pub ws_endpoint: String,
+    pub proof_poll_period_secs: u64,
+    pub min_batch_count: usize,
+    pub max_batch_count: usize,
+    pub max_proof_batch_size: usize,
+    pub epoch_end_window_secs: u64,
+}
+
+impl ChainInfo {
+    pub fn empty(peer_id: String) -> ChainInfo {
+        ChainInfo {
+            peer_id,
+            http_endpoint: "".to_string(),
+            diamond_contract_address: "".to_string(),
+            network_id: 0,
+            default_base_fee: None,
+            default_priority_fee: None,
+            ws_endpoint: "".to_string(),
+            proof_poll_period_secs: 0,
+            min_batch_count: 0,
+            max_batch_count: 0,
+            max_proof_batch_size: 0,
+            epoch_end_window_secs: 0,
+        }
+    }
+}
+
 pub fn add_info_metrics(
+    registry: &mut Registry,
+    nox_info: NoxInfo,
+) {
+    let sub_registry = registry.sub_registry_with_prefix("nox");
+
+    let info = Info::new(nox_info.versions);
+    sub_registry.register("build", "Nox Info", info);
+
+    let chain_info = Info::new(nox_info.chain_info);
+    sub_registry.register("chain", "Chain Nox Info", chain_info);
+}
+
+pub fn add_info_metrics2(
     registry: &mut Registry,
     node_version: String,
     air_version: String,
     spell_version: String,
 ) {
     let sub_registry = registry.sub_registry_with_prefix("nox");
+
     let info = Info::new(vec![
         ("node_version", node_version),
         ("air_version", air_version),
         ("spell_version", spell_version),
     ]);
     sub_registry.register("build", "Nox Info", info);
+}
+
+#[test]
+fn test() {
+    let mut reg = Registry::default();
+    let info = NoxInfo {
+        versions: NoxVersions {
+            node_version: "0.1.0".to_string(),
+            air_version: "0.1.0".to_string(),
+            spell_version: "0.1.0".to_string(),
+        },
+        chain_info: ChainInfo {
+            peer_id: "0x123".to_string(),
+            http_endpoint: "http://localhost:8545".to_string(),
+            diamond_contract_address: "0x123".to_string(),
+            network_id: 1,
+            default_base_fee: Some(1),
+            default_priority_fee: Some(1),
+            ws_endpoint: "ws://localhost:8546".to_string(),
+            proof_poll_period_secs: 1,
+            min_batch_count: 1,
+            max_batch_count: 1,
+            max_proof_batch_size: 1,
+            epoch_end_window_secs: 1,
+        },
+    };
+    add_info_metrics(&mut reg, info);
+
+    let mut buf = String::new();
+
+    encode(&mut buf, &reg);
+    println!("{buf}");
 }

--- a/crates/peer-metrics/src/lib.rs
+++ b/crates/peer-metrics/src/lib.rs
@@ -27,7 +27,7 @@ pub use connection_pool::ConnectionPoolMetrics;
 pub use connectivity::ConnectivityMetrics;
 pub use connectivity::Resolution;
 pub use dispatcher::DispatcherMetrics;
-pub use info::{add_info_metrics, NoxInfo, NoxVersions, ChainInfo};
+pub use info::{add_info_metrics, NoxInfo, NoxVersion, ChainInfo};
 use particle_execution::ParticleParams;
 pub use particle_executor::{FunctionKind, ParticleExecutorMetrics, WorkerLabel, WorkerType};
 pub use services_metrics::{

--- a/crates/peer-metrics/src/lib.rs
+++ b/crates/peer-metrics/src/lib.rs
@@ -27,7 +27,7 @@ pub use connection_pool::ConnectionPoolMetrics;
 pub use connectivity::ConnectivityMetrics;
 pub use connectivity::Resolution;
 pub use dispatcher::DispatcherMetrics;
-pub use info::{add_info_metrics, NoxInfo, NoxVersion, ChainInfo};
+pub use info::{add_info_metrics, ChainInfo, NoxInfo, NoxVersion};
 use particle_execution::ParticleParams;
 pub use particle_executor::{FunctionKind, ParticleExecutorMetrics, WorkerLabel, WorkerType};
 pub use services_metrics::{

--- a/crates/peer-metrics/src/lib.rs
+++ b/crates/peer-metrics/src/lib.rs
@@ -27,7 +27,7 @@ pub use connection_pool::ConnectionPoolMetrics;
 pub use connectivity::ConnectivityMetrics;
 pub use connectivity::Resolution;
 pub use dispatcher::DispatcherMetrics;
-pub use info::add_info_metrics;
+pub use info::{add_info_metrics, NoxInfo, NoxVersions, ChainInfo};
 use particle_execution::ParticleParams;
 pub use particle_executor::{FunctionKind, ParticleExecutorMetrics, WorkerLabel, WorkerType};
 pub use services_metrics::{

--- a/crates/server-config/Cargo.toml
+++ b/crates/server-config/Cargo.toml
@@ -10,7 +10,6 @@ fs-utils = { workspace = true }
 particle-protocol = { workspace = true }
 fluence-libp2p = { workspace = true, features = ["tokio"] }
 air-interpreter-fs = { workspace = true }
-peer-metrics = { workspace = true }
 fluence-keypair = { workspace = true }
 types = { workspace = true }
 core-distributor = { workspace = true }

--- a/crates/server-config/src/network_config.rs
+++ b/crates/server-config/src/network_config.rs
@@ -25,7 +25,6 @@ use std::time::Duration;
 
 use config_utils::to_peer_id;
 use particle_protocol::ProtocolConfig;
-use peer_metrics::{ConnectionPoolMetrics, ConnectivityMetrics};
 
 use crate::kademlia_config::KademliaConfig;
 use crate::{BootstrapConfig, ResolvedConfig};
@@ -41,8 +40,6 @@ pub struct NetworkConfig {
     pub kademlia_config: KademliaConfig,
     pub particle_queue_buffer: usize,
     pub bootstrap_frequency: usize,
-    pub connectivity_metrics: Option<ConnectivityMetrics>,
-    pub connection_pool_metrics: Option<ConnectionPoolMetrics>,
     pub connection_limits: ConnectionLimits,
     pub connection_idle_timeout: Duration,
 }
@@ -50,8 +47,6 @@ pub struct NetworkConfig {
 impl NetworkConfig {
     pub fn new(
         libp2p_metrics: Option<Arc<Metrics>>,
-        connectivity_metrics: Option<ConnectivityMetrics>,
-        connection_pool_metrics: Option<ConnectionPoolMetrics>,
         key_pair: Keypair,
         config: &ResolvedConfig,
         node_version: &'static str,
@@ -68,8 +63,6 @@ impl NetworkConfig {
             kademlia_config: config.kademlia.clone(),
             particle_queue_buffer: config.particle_queue_buffer,
             bootstrap_frequency: config.bootstrap_frequency,
-            connectivity_metrics,
-            connection_pool_metrics,
             connection_limits,
             connection_idle_timeout: config.node_config.transport_config.connection_idle_timeout,
         }

--- a/nox/src/behaviour/network.rs
+++ b/nox/src/behaviour/network.rs
@@ -30,6 +30,7 @@ use connection_pool::ConnectionPoolBehaviour;
 use health::HealthCheckRegistry;
 use kademlia::{Kademlia, KademliaConfig};
 use particle_protocol::{ExtendedParticle, PROTOCOL_NAME};
+use peer_metrics::{ConnectionPoolMetrics, ConnectivityMetrics};
 use server_config::NetworkConfig;
 
 use crate::connectivity::Connectivity;
@@ -68,6 +69,8 @@ impl FluenceNetworkBehaviour {
     pub fn new(
         cfg: NetworkConfig,
         health_registry: Option<&mut HealthCheckRegistry>,
+        connectivity_metrics: Option<ConnectivityMetrics>,
+        connection_pool_metrics: Option<ConnectionPoolMetrics>,
     ) -> (Self, Connectivity, mpsc::Receiver<ExtendedParticle>) {
         let local_public_key = cfg.key_pair.public();
         let identify = Identify::new(
@@ -86,7 +89,7 @@ impl FluenceNetworkBehaviour {
             cfg.particle_queue_buffer,
             cfg.protocol_config,
             cfg.local_peer_id,
-            cfg.connection_pool_metrics,
+            connection_pool_metrics,
         );
 
         let connection_limits = ConnectionLimits::new(cfg.connection_limits);
@@ -119,7 +122,7 @@ impl FluenceNetworkBehaviour {
             connection_pool: connection_pool_api,
             bootstrap_nodes: cfg.bootstrap_nodes.into_iter().collect(),
             bootstrap_frequency: cfg.bootstrap_frequency,
-            metrics: cfg.connectivity_metrics,
+            metrics: connectivity_metrics,
             health,
         };
 

--- a/nox/src/node.rs
+++ b/nox/src/node.rs
@@ -280,8 +280,8 @@ impl<RT: AquaRuntime> Node<RT> {
 
         let network_config = NetworkConfig::new(
             libp2p_metrics.clone(),
-            connectivity_metrics,
-            connection_pool_metrics,
+            //connectivity_metrics,
+            //connection_pool_metrics,
             key_pair,
             &config,
             node_version,
@@ -297,6 +297,8 @@ impl<RT: AquaRuntime> Node<RT> {
             config.external_addresses(),
             health_registry.as_mut(),
             metrics_registry.as_mut(),
+            connectivity_metrics,
+            connection_pool_metrics,
         )?;
 
         let (services_metrics_backend, services_metrics) =
@@ -526,6 +528,8 @@ impl<RT: AquaRuntime> Node<RT> {
         external_addresses: Vec<Multiaddr>,
         health_registry: Option<&mut HealthCheckRegistry>,
         metrics_registry: Option<&mut Registry>,
+        connectivity_metrics: Option<ConnectivityMetrics>,
+        connection_pool_metrics: Option<ConnectionPoolMetrics>,
     ) -> eyre::Result<(
         Swarm<FluenceNetworkBehaviour>,
         Connectivity,
@@ -534,7 +538,7 @@ impl<RT: AquaRuntime> Node<RT> {
         let connection_idle_timeout = network_config.connection_idle_timeout;
 
         let (behaviour, connectivity, particle_stream) =
-            FluenceNetworkBehaviour::new(network_config, health_registry);
+            FluenceNetworkBehaviour::new(network_config, health_registry, connectivity_metrics, connection_pool_metrics);
 
         let mut swarm = match metrics_registry {
             None => SwarmBuilder::with_existing_identity(key_pair)

--- a/nox/src/node.rs
+++ b/nox/src/node.rs
@@ -420,7 +420,7 @@ impl<RT: AquaRuntime> Node<RT> {
             }),
         };
         if let Some(m) = metrics_registry.as_mut() {
-            let mut chain_info = peer_metrics::ChainInfo::empty(peer_id.to_string());
+            let mut chain_info = peer_metrics::ChainInfo::default(peer_id.to_string());
             if let Some(connector_cfg) = &config.chain_config {
                 chain_info.http_endpoint = connector_cfg.http_endpoint.clone();
                 chain_info.diamond_contract_address = connector_cfg.diamond_contract_address.clone();
@@ -439,7 +439,7 @@ impl<RT: AquaRuntime> Node<RT> {
             }
 
             let nox_info = peer_metrics::NoxInfo {
-                versions: peer_metrics::NoxVersions {
+                version: peer_metrics::NoxVersion {
                     node_version: node_info.node_version.to_string(),
                     air_version: node_info.air_version.to_string(),
                     spell_version: node_info.spell_version.to_string(),

--- a/nox/src/node.rs
+++ b/nox/src/node.rs
@@ -423,7 +423,8 @@ impl<RT: AquaRuntime> Node<RT> {
             let mut chain_info = peer_metrics::ChainInfo::default(peer_id.to_string());
             if let Some(connector_cfg) = &config.chain_config {
                 chain_info.http_endpoint = connector_cfg.http_endpoint.clone();
-                chain_info.diamond_contract_address = connector_cfg.diamond_contract_address.clone();
+                chain_info.diamond_contract_address =
+                    connector_cfg.diamond_contract_address.clone();
                 chain_info.network_id = connector_cfg.network_id;
                 chain_info.default_base_fee = connector_cfg.default_base_fee.clone();
                 chain_info.default_priority_fee = connector_cfg.default_priority_fee.clone();
@@ -559,8 +560,12 @@ impl<RT: AquaRuntime> Node<RT> {
     )> {
         let connection_idle_timeout = network_config.connection_idle_timeout;
 
-        let (behaviour, connectivity, particle_stream) =
-            FluenceNetworkBehaviour::new(network_config, health_registry, connectivity_metrics, connection_pool_metrics);
+        let (behaviour, connectivity, particle_stream) = FluenceNetworkBehaviour::new(
+            network_config,
+            health_registry,
+            connectivity_metrics,
+            connection_pool_metrics,
+        );
 
         let mut swarm = match metrics_registry {
             None => SwarmBuilder::with_existing_identity(key_pair)


### PR DESCRIPTION
## Description
Add a chain info metric with chain configuration

## Proposed Changes
- Refactor a bit to remove `server-config` dependency on `peer-metrics`. It turned out to be useless in this PR, but maybe will be helpful in the next one with more configs
- Add `current_commitment_status`. The status is a number which corresponds to the CCStatus enum in chain_listener.
- Add `nox_chain_info` metric. Example:
```
# HELP nox_chain Chain Nox Info.
# TYPE nox_chain info
nox_chain_info{peer_id="0x123",http_endpoint="http://localhost:8545",diamond_contract_address="0x123",network_id="1",default_base_fee="1",default_priority_fee="1",ws_endpoint="ws://localhost:8546",proof_poll_period="1s",min_batch_count="1",max_batch_count="1",max_proof_batch_size="1",epoch_end_window="1s"} 1
# EOF
```

