### PR TITLE
fix(vm): close libvirt connections

### DIFF
--- a/crates/vm-utils/src/vm_utils.rs
+++ b/crates/vm-utils/src/vm_utils.rs
@@ -163,7 +163,7 @@ struct AutocloseConnect(Connect);
 impl AutocloseConnect {
     fn open(uri: &str) -> Result<Self, VmError> {
         Connect::open(Some(uri))
-            .map(|conn| Self(conn))
+            .map(Self)
             .map_err(|err| VmError::FailedToConnect { err })
     }
 }
@@ -326,11 +326,10 @@ pub fn status_vm(uri: &str, name: &str) -> Result<VmStatus, VmError> {
         name: name.to_string(),
         err,
     })?;
-    let status = get_status(&domain).map_err(|err| VmError::FailedToGetInfo {
+    get_status(&domain).map_err(|err| VmError::FailedToGetInfo {
         name: name.to_string(),
         err,
-    });
-    status
+    })
 }
 
 fn get_status(domain: &Domain) -> Result<VmStatus, virt::error::Error> {


### PR DESCRIPTION
## Description
Close libvirt connection when we're done.

## Motivation
We found a problem with `Too many files` on one of our provider's machines when deploying a deal on it: the nox process has too many open eventfd connections. Further investigation showed that the problem is that the `Connection` struct of the `virt` crate doesn't implement `Drop`, so the connection isn't closed. 


## Proposed Changes
Auto-close connection.

